### PR TITLE
Cr-350 address change event

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/common/event/EventPublisher.java
+++ b/src/main/java/uk/gov/ons/ctp/common/event/EventPublisher.java
@@ -7,6 +7,9 @@ import java.util.Date;
 import java.util.List;
 import java.util.UUID;
 import lombok.Getter;
+import uk.gov.ons.ctp.common.event.model.AddressModification;
+import uk.gov.ons.ctp.common.event.model.AddressModifiedEvent;
+import uk.gov.ons.ctp.common.event.model.AddressModifiedPayload;
 import uk.gov.ons.ctp.common.event.model.CaseEvent;
 import uk.gov.ons.ctp.common.event.model.CasePayload;
 import uk.gov.ons.ctp.common.event.model.CollectionCase;
@@ -78,7 +81,7 @@ public class EventPublisher {
 
   @Getter
   public enum EventType {
-    ADDRESS_MODIFIED,
+    ADDRESS_MODIFIED(AddressModification.class),
     ADDRESS_NOT_VALID,
     ADDRESS_TYPE_CHANGED,
     APPOINTMENT_REQUESTED,
@@ -210,6 +213,15 @@ public class EventPublisher {
             new RespondentRefusalPayload((RespondentRefusalDetails) payload);
         respondentRefusalEvent.setPayload(respondentRefusalPayload);
         genericEvent = respondentRefusalEvent;
+        break;
+
+      case ADDRESS_MODIFIED:
+        AddressModifiedEvent addressModifiedEvent = new AddressModifiedEvent();
+        addressModifiedEvent.setEvent(buildHeader(eventType, source, channel));
+        AddressModifiedPayload addressModifiedPayload =
+            new AddressModifiedPayload((AddressModification) payload);
+        addressModifiedEvent.setPayload(addressModifiedPayload);
+        genericEvent = addressModifiedEvent;
         break;
 
       default:

--- a/src/main/java/uk/gov/ons/ctp/common/event/model/AddressModification.java
+++ b/src/main/java/uk/gov/ons/ctp/common/event/model/AddressModification.java
@@ -1,0 +1,17 @@
+package uk.gov.ons.ctp.common.event.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AddressModification implements EventPayload {
+
+  private CollectionCaseCompact collectionCase;
+  private AddressModified originalAddress;
+  private AddressModified newAddress;
+}

--- a/src/main/java/uk/gov/ons/ctp/common/event/model/AddressModified.java
+++ b/src/main/java/uk/gov/ons/ctp/common/event/model/AddressModified.java
@@ -1,0 +1,20 @@
+package uk.gov.ons.ctp.common.event.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class AddressModified {
+
+  private String addressLine1;
+  private String addressLine2;
+  private String addressLine3;
+  private String townName;
+  private String postcode;
+  private String region; // E, W or N
+  private String uprn;
+  private String arid;
+}

--- a/src/main/java/uk/gov/ons/ctp/common/event/model/AddressModifiedEvent.java
+++ b/src/main/java/uk/gov/ons/ctp/common/event/model/AddressModifiedEvent.java
@@ -1,0 +1,15 @@
+package uk.gov.ons.ctp.common.event.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+@NoArgsConstructor
+@AllArgsConstructor
+public class AddressModifiedEvent extends GenericEvent {
+
+  private AddressModifiedPayload payload = new AddressModifiedPayload();
+}

--- a/src/main/java/uk/gov/ons/ctp/common/event/model/AddressModifiedPayload.java
+++ b/src/main/java/uk/gov/ons/ctp/common/event/model/AddressModifiedPayload.java
@@ -1,0 +1,13 @@
+package uk.gov.ons.ctp.common.event.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class AddressModifiedPayload {
+
+  private AddressModification addressModification = new AddressModification();
+}


### PR DESCRIPTION
# Motivation and Context
Support for AddressModified event added to Event Publisher.

# What has changed
AddressModifiedEvent class added with associated payload classes and addition to EventPublisher class.

# How to test?
Unit test updated to include AddressModifiedEvent. Detailed unit test using all properties of AddressModified class is in census-rh-service project where AddressModified event is published.