### PR TITLE
Cr 423 rabbit support for cucumber tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,5 @@ This project contains a utility class for creating and publishing Rabbit AMQP Ce
 
 ## Copyright
 Copyright (C) 2019 Crown Copyright (Office for National Statistics)
+
+

--- a/pom.xml
+++ b/pom.xml
@@ -76,18 +76,22 @@
     </dependency>
 
     <dependency>
-      <groupId>uk.gov.ons.ctp.integration.common</groupId>
-      <artifactId>framework</artifactId>
-      <version>0.0.34</version>
-    </dependency>
-
-    <dependency>
-      <groupId>uk.gov.ons.ctp.integration.common</groupId>
-      <artifactId>test-framework</artifactId>
-      <version>0.0.4</version>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
-
+    
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    
+    <dependency>
+      <groupId>uk.gov.ons.ctp.integration.common</groupId>
+      <artifactId>framework</artifactId>
+      <version>0.0.35-SNAPSHOT</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -76,21 +76,16 @@
     </dependency>
 
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <scope>test</scope>
+      <groupId>uk.gov.ons.ctp.integration.common</groupId>
+      <artifactId>framework</artifactId>
+      <version>0.0.35-SNAPSHOT</version>
     </dependency>
     
     <dependency>
       <groupId>uk.gov.ons.ctp.integration.common</groupId>
-      <artifactId>framework</artifactId>
-      <version>0.0.35-SNAPSHOT</version>
+      <artifactId>test-framework</artifactId>
+      <version>0.0.7-SNAPSHOT</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -78,13 +78,13 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration.common</groupId>
       <artifactId>framework</artifactId>
-      <version>0.0.35-SNAPSHOT</version>
+      <version>0.0.34</version>
     </dependency>
     
     <dependency>
       <groupId>uk.gov.ons.ctp.integration.common</groupId>
       <artifactId>test-framework</artifactId>
-      <version>0.0.7-SNAPSHOT</version>
+      <version>0.0.6</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/uk/gov/ons/ctp/common/event/NativeRabbitEventSender.java
+++ b/src/main/java/uk/gov/ons/ctp/common/event/NativeRabbitEventSender.java
@@ -1,0 +1,60 @@
+package uk.gov.ons.ctp.common.event;
+
+import java.io.IOException;
+import java.util.concurrent.TimeoutException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.Connection;
+import com.rabbitmq.client.ConnectionFactory;
+import uk.gov.ons.ctp.common.error.CTPException;
+import uk.gov.ons.ctp.common.error.CTPException.Fault;
+import uk.gov.ons.ctp.common.event.EventPublisher.RoutingKey;
+import uk.gov.ons.ctp.common.event.model.GenericEvent;
+
+public class NativeRabbitEventSender implements EventSender {
+  private static final Logger log = LoggerFactory.getLogger(NativeRabbitEventSender.class);
+
+  Connection connection;
+  String exchange;
+  Channel channel;
+
+  ObjectMapper objectMapper;
+
+  public NativeRabbitEventSender(RabbitConnectionDetails connectionDetails, String exchange)
+      throws CTPException {
+    objectMapper = new ObjectMapper();
+
+    ConnectionFactory factory = new ConnectionFactory();
+    factory.setHost(connectionDetails.getHost());
+    factory.setPort(connectionDetails.getPort());
+    factory.setUsername(connectionDetails.getUser());
+    factory.setPassword(connectionDetails.getPassword());
+    connection = null;
+    try {
+      connection = factory.newConnection();
+      this.exchange = exchange;
+      channel = connection.createChannel();
+      channel.exchangeDeclare(exchange, "topic", true);
+    } catch (TimeoutException | IOException e) {
+      String errorMessage = "Failed to connect to Rabbit";
+      log.error(e, errorMessage);
+      throw new CTPException(Fault.SYSTEM_ERROR, errorMessage);
+    }
+  }
+
+  @Override
+  public void close() throws IOException {
+    connection.close();
+  }
+
+  @Override
+  public void sendEvent(RoutingKey routingKey, GenericEvent genericEvent) throws Exception {
+    channel.basicPublish(
+        exchange,
+        routingKey.getKey(),
+        null,
+        objectMapper.writeValueAsString(genericEvent).getBytes("UTF-8"));
+  }
+}

--- a/src/main/java/uk/gov/ons/ctp/common/event/NativeRabbitEventSender.java
+++ b/src/main/java/uk/gov/ons/ctp/common/event/NativeRabbitEventSender.java
@@ -1,13 +1,13 @@
 package uk.gov.ons.ctp.common.event;
 
-import java.io.IOException;
-import java.util.concurrent.TimeoutException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.godaddy.logging.Logger;
 import com.godaddy.logging.LoggerFactory;
 import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.Connection;
 import com.rabbitmq.client.ConnectionFactory;
+import java.io.IOException;
+import java.util.concurrent.TimeoutException;
 import uk.gov.ons.ctp.common.error.CTPException;
 import uk.gov.ons.ctp.common.error.CTPException.Fault;
 import uk.gov.ons.ctp.common.event.EventPublisher.RoutingKey;

--- a/src/main/java/uk/gov/ons/ctp/common/event/RabbitConnectionDetails.java
+++ b/src/main/java/uk/gov/ons/ctp/common/event/RabbitConnectionDetails.java
@@ -1,0 +1,15 @@
+package uk.gov.ons.ctp.common.event;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class RabbitConnectionDetails {
+  private String host;
+  private Integer port;
+  private String user;
+  private String password;
+}

--- a/src/test/java/uk/gov/ons/ctp/common/event/EventPublisherTest.java
+++ b/src/test/java/uk/gov/ons/ctp/common/event/EventPublisherTest.java
@@ -37,7 +37,6 @@ import uk.gov.ons.ctp.common.event.model.SurveyLaunchedResponse;
 @RunWith(MockitoJUnitRunner.class)
 public class EventPublisherTest {
 
-  private static final String ROUTING_KEY = "whereAreWeRoutingThis";
   private static final UUID CASE_ID = UUID.fromString("dc4477d1-dd3f-4c69-b181-7ff725dc9fa4");
   private static final String QUESTIONNAIRE_ID = "1110000009";
 


### PR DESCRIPTION
Moved NativeRabbitEventSender into this project.
This location allows messages to be sent by the EventGenerator and also by CucumberCommon.