### PR TITLE
CR-423 Connection details now coming from structured yml file. Modify…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration.common</groupId>
       <artifactId>framework</artifactId>
-      <version>0.0.34</version>
+      <version>0.0.35</version>
     </dependency>
     
     <dependency>

--- a/src/main/java/uk/gov/ons/ctp/common/event/NativeRabbitEventSender.java
+++ b/src/main/java/uk/gov/ons/ctp/common/event/NativeRabbitEventSender.java
@@ -48,7 +48,7 @@ public class NativeRabbitEventSender implements EventSender {
     ConnectionFactory factory = new ConnectionFactory();
     factory.setHost(connectionDetails.getHost());
     factory.setPort(connectionDetails.getPort());
-    factory.setUsername(connectionDetails.getUser());
+    factory.setUsername(connectionDetails.getUsername());
     factory.setPassword(connectionDetails.getPassword());
 
     try {

--- a/src/main/java/uk/gov/ons/ctp/common/event/RabbitConnectionDetails.java
+++ b/src/main/java/uk/gov/ons/ctp/common/event/RabbitConnectionDetails.java
@@ -1,5 +1,6 @@
 package uk.gov.ons.ctp.common.event;
 
+import com.fasterxml.jackson.annotation.JsonRootName;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -7,9 +8,10 @@ import lombok.NoArgsConstructor;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
+@JsonRootName("rabbitmq")
 public class RabbitConnectionDetails {
   private String host;
   private Integer port;
-  private String user;
+  private String username;
   private String password;
 }


### PR DESCRIPTION
… code to match project config conventions.

Changes:
1) Rabbit connection details uses the usual 'username' instead of 'user'.
2) RabbitConnectionDetails expects to be extracted from a 'rabbitmq' section of the config file.