### PR TITLE
CR-423 Using newer common service which will read rabbit config as a …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,10 +75,12 @@
       <artifactId>logging</artifactId>
     </dependency>
 
+    <!-- ONS libraries -->
+
     <dependency>
       <groupId>uk.gov.ons.ctp.integration.common</groupId>
       <artifactId>framework</artifactId>
-      <version>0.0.35</version>
+      <version>0.0.36</version>
     </dependency>
     
     <dependency>


### PR DESCRIPTION
…stream

Bug fix for CR-423.
Use latest version of common-service which contains the fix.