### PR TITLE
CR-470 Added support for publication of feedback events

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/common/event/EventPublisher.java
+++ b/src/main/java/uk/gov/ons/ctp/common/event/EventPublisher.java
@@ -14,6 +14,9 @@ import uk.gov.ons.ctp.common.event.model.CaseEvent;
 import uk.gov.ons.ctp.common.event.model.CasePayload;
 import uk.gov.ons.ctp.common.event.model.CollectionCase;
 import uk.gov.ons.ctp.common.event.model.EventPayload;
+import uk.gov.ons.ctp.common.event.model.Feedback;
+import uk.gov.ons.ctp.common.event.model.FeedbackEvent;
+import uk.gov.ons.ctp.common.event.model.FeedbackPayload;
 import uk.gov.ons.ctp.common.event.model.FulfilmentPayload;
 import uk.gov.ons.ctp.common.event.model.FulfilmentRequest;
 import uk.gov.ons.ctp.common.event.model.FulfilmentRequestedEvent;
@@ -62,7 +65,8 @@ public class EventPublisher {
     EVENT_CASE_APPOINTMENT("event.case.appointment", EventType.APPOINTMENT_REQUESTED),
     EVENT_FIELD_CASE_UPDATE("event.fieldcase.update", EventType.FIELD_CASE_UPDATED),
     EVENT_SAMPLE_UNIT_UPDATE("event.sampleunit.update", EventType.SAMPLE_UNIT_VALIDATED),
-    EVENT_CCS_PROPERTY_LISTING("event.ccs.propertylisting", EventType.CCS_PROPERTY_LISTED);
+    EVENT_CCS_PROPERTY_LISTING("event.ccs.propertylisting", EventType.CCS_PROPERTY_LISTED),
+    FEEDBACK("event.website.feedback", EventType.FEEDBACK);
 
     private String key;
     private List<EventType> eventTypes;
@@ -102,7 +106,8 @@ public class EventPublisher {
     SAMPLE_UNIT_VALIDATED,
     SURVEY_LAUNCHED(SurveyLaunchedResponse.class),
     UAC_UPDATED(UAC.class),
-    UNDELIVERED_MAIL_REPORTED;
+    UNDELIVERED_MAIL_REPORTED,
+    FEEDBACK(Feedback.class);
 
     private Class<? extends EventPayload> payloadType;
 
@@ -248,6 +253,14 @@ public class EventPublisher {
             new AddressModifiedPayload((AddressModification) payload);
         addressModifiedEvent.setPayload(addressModifiedPayload);
         genericEvent = addressModifiedEvent;
+        break;
+
+      case FEEDBACK:
+        FeedbackEvent feedbackEvent = new FeedbackEvent();
+        feedbackEvent.setEvent(buildHeader(eventType, source, channel));
+        FeedbackPayload feedbackPayload = new FeedbackPayload((Feedback) payload);
+        feedbackEvent.setPayload(feedbackPayload);
+        genericEvent = feedbackEvent;
         break;
 
       default:

--- a/src/main/java/uk/gov/ons/ctp/common/event/model/Feedback.java
+++ b/src/main/java/uk/gov/ons/ctp/common/event/model/Feedback.java
@@ -1,0 +1,15 @@
+package uk.gov.ons.ctp.common.event.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class Feedback implements EventPayload {
+
+  private String pageUrl;
+  private String pageTitle;
+  private String feedbackText;
+}

--- a/src/main/java/uk/gov/ons/ctp/common/event/model/FeedbackEvent.java
+++ b/src/main/java/uk/gov/ons/ctp/common/event/model/FeedbackEvent.java
@@ -1,0 +1,15 @@
+package uk.gov.ons.ctp.common.event.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+@NoArgsConstructor
+@AllArgsConstructor
+public class FeedbackEvent extends GenericEvent {
+
+  private FeedbackPayload payload = new FeedbackPayload();
+}

--- a/src/main/java/uk/gov/ons/ctp/common/event/model/FeedbackPayload.java
+++ b/src/main/java/uk/gov/ons/ctp/common/event/model/FeedbackPayload.java
@@ -1,0 +1,13 @@
+package uk.gov.ons.ctp.common.event.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class FeedbackPayload {
+
+  private Feedback feedback = new Feedback();
+}

--- a/src/test/java/uk/gov/ons/ctp/common/event/EventPublisherTest.java
+++ b/src/test/java/uk/gov/ons/ctp/common/event/EventPublisherTest.java
@@ -251,7 +251,7 @@ public class EventPublisherTest {
 
     String transactionId =
         eventPublisher.sendEvent(
-            EventType.FEEDBACK, Source.RESPONDENT_HOME, Channel.RM, feedbackResponse);
+            EventType.FEEDBACK, Source.RESPONDENT_HOME, Channel.RH, feedbackResponse);
 
     RoutingKey routingKey = RoutingKey.forType(EventType.FEEDBACK);
     verify(sender, times(1)).sendEvent(eq(routingKey), eventCapture.capture());
@@ -261,7 +261,7 @@ public class EventPublisherTest {
     assertThat(UUID.fromString(event.getEvent().getTransactionId()), instanceOf(UUID.class));
     assertEquals(EventPublisher.EventType.FEEDBACK, event.getEvent().getType());
     assertEquals(EventPublisher.Source.RESPONDENT_HOME, event.getEvent().getSource());
-    assertEquals(EventPublisher.Channel.RM, event.getEvent().getChannel());
+    assertEquals(EventPublisher.Channel.RH, event.getEvent().getChannel());
     assertThat(event.getEvent().getDateTime(), instanceOf(Date.class));
     assertEquals("url-x", event.getPayload().getFeedback().getPageUrl());
     assertEquals("randomPage", event.getPayload().getFeedback().getPageTitle());


### PR DESCRIPTION
This branch allows the EventPublisher to send feedback events. This has initially been added for the RH UI, to allow an end-user to enter feedback about the website.

The unit tests have been extended to cover the new code.

Reviewer: Please verify that the channel has been set correctly. Code currently uses 'RM'.
