### PR TITLE
Cr 631

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration.common</groupId>
       <artifactId>framework</artifactId>
-      <version>0.0.40</version>
+      <version>0.0.48</version>
     </dependency>
     
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,11 @@
       <artifactId>logging</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.springframework.amqp</groupId>
+      <artifactId>spring-rabbit</artifactId>
+    </dependency>
+
     <!-- ONS libraries -->
 
     <dependency>


### PR DESCRIPTION
The pom has been changed to include a dependency on spring-rabbit, which had previously been unnecessary due to that dependency already existing in the census-int-common-service.

This change removes the need for the census-int-common-service to include a dependency on spring-rabbit any more.