### PR TITLE
update the version of common service so that it no longer pulls in th…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration.common</groupId>
       <artifactId>framework</artifactId>
-      <version>0.0.48</version>
+      <version>0.0.49</version>
     </dependency>
     
     <dependency>


### PR DESCRIPTION
The pom has been changed to point to version 0.0.49 of census-int-common-service, which has no dependencies on spring-rabbit. Therefore the census-int-event-publisher will use its own dependency on spring-rabbit instead.