### PR TITLE
Adding formType to UAC event

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/common/event/model/UAC.java
+++ b/src/main/java/uk/gov/ons/ctp/common/event/model/UAC.java
@@ -20,4 +20,5 @@ public class UAC implements EventPayload {
   private String region;
   private String caseId;
   private String collectionExerciseId;
+  private String formType;
 }


### PR DESCRIPTION
This new field on the UAC event needs adding so that parts of the RH service can consume it and send it back to the UI.