### PR TITLE
CR-871 added UAC_CREATED event type

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,9 +85,9 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration.common</groupId>
       <artifactId>framework</artifactId>
-      <version>0.0.51</version>
+      <version>0.0.52</version>
     </dependency>
-    
+
     <dependency>
       <groupId>uk.gov.ons.ctp.integration.common</groupId>
       <artifactId>test-framework</artifactId>

--- a/src/main/java/uk/gov/ons/ctp/common/event/EventPublisher.java
+++ b/src/main/java/uk/gov/ons/ctp/common/event/EventPublisher.java
@@ -56,7 +56,7 @@ public class EventPublisher {
         EventType.SURVEY_LAUNCHED),
     EVENT_RESPONSE_RECEIPT("event.response.receipt", EventType.RESPONSE_RECEIVED),
     EVENT_RESPONDENT_REFUSAL("event.respondent.refusal", EventType.REFUSAL_RECEIVED),
-    EVENT_UAC_UPDATE("event.uac.update", EventType.UAC_UPDATED),
+    EVENT_UAC_UPDATE("event.uac.update", EventType.UAC_UPDATED, EventType.UAC_CREATED),
     EVENT_QUESTIONNAIRE_UPDATE("event.questionnaire.update", EventType.QUESTIONNAIRE_LINKED),
     EVENT_CASE_UPDATE("event.case.update", EventType.CASE_UPDATED, EventType.CASE_CREATED),
     EVENT_CASE_ADDRESS_UPDATE(
@@ -108,6 +108,7 @@ public class EventPublisher {
     RESPONSE_RECEIVED,
     SAMPLE_UNIT_VALIDATED,
     SURVEY_LAUNCHED(SurveyLaunchedResponse.class),
+    UAC_CREATED(UAC.class),
     UAC_UPDATED(UAC.class),
     UNDELIVERED_MAIL_REPORTED,
     FEEDBACK(Feedback.class);
@@ -238,6 +239,7 @@ public class EventPublisher {
         genericEvent = respondentRefusalEvent;
         break;
 
+      case UAC_CREATED:
       case UAC_UPDATED:
         UACEvent uacEvent = new UACEvent();
         uacEvent.setEvent(buildHeader(eventType, source, channel));

--- a/src/main/java/uk/gov/ons/ctp/common/event/model/CaseEvent.java
+++ b/src/main/java/uk/gov/ons/ctp/common/event/model/CaseEvent.java
@@ -2,9 +2,11 @@ package uk.gov.ons.ctp.common.event.model;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
 @Data
+@EqualsAndHashCode(callSuper = true)
 @NoArgsConstructor
 @AllArgsConstructor
 public class CaseEvent extends GenericEvent {

--- a/src/main/java/uk/gov/ons/ctp/common/event/model/FulfilmentRequestedEvent.java
+++ b/src/main/java/uk/gov/ons/ctp/common/event/model/FulfilmentRequestedEvent.java
@@ -2,9 +2,11 @@ package uk.gov.ons.ctp.common.event.model;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
 @Data
+@EqualsAndHashCode(callSuper = true)
 @NoArgsConstructor
 @AllArgsConstructor
 public class FulfilmentRequestedEvent extends GenericEvent {

--- a/src/main/java/uk/gov/ons/ctp/common/event/model/RespondentAuthenticatedEvent.java
+++ b/src/main/java/uk/gov/ons/ctp/common/event/model/RespondentAuthenticatedEvent.java
@@ -2,9 +2,11 @@ package uk.gov.ons.ctp.common.event.model;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
 @Data
+@EqualsAndHashCode(callSuper = true)
 @NoArgsConstructor
 @AllArgsConstructor
 public class RespondentAuthenticatedEvent extends GenericEvent {

--- a/src/main/java/uk/gov/ons/ctp/common/event/model/UACEvent.java
+++ b/src/main/java/uk/gov/ons/ctp/common/event/model/UACEvent.java
@@ -2,9 +2,11 @@ package uk.gov.ons.ctp.common.event.model;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
 @Data
+@EqualsAndHashCode(callSuper = true)
 @NoArgsConstructor
 @AllArgsConstructor
 public class UACEvent extends GenericEvent {


### PR DESCRIPTION
Just modelled the new type on CASE_CREATED/UPDATED duality, so UAC_CREATED uses the same rabbit routing key as UAC_UPDATED.

RH service and RH cucumber (new) tests have been run in DEV to prove all is OK.

When this PR is approved , I can create the following PRs for RH service and cucumber tests.