### PR TITLE
Cr 1063 upadate fields for refusal recieved

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>uk.gov.ons.ctp.integration.common</groupId>
   <artifactId>event-publisher</artifactId>
-  <version>0.0.41-CR1063-SNAPSHOT</version>
+  <version>0.0.41-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>CTP : Integration Event Publisher</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>uk.gov.ons.ctp.integration.common</groupId>
   <artifactId>event-publisher</artifactId>
-  <version>0.0.41-SNAPSHOT</version>
+  <version>0.0.41-CR1063-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>CTP : Integration Event Publisher</name>

--- a/src/main/java/uk/gov/ons/ctp/common/event/model/Contact.java
+++ b/src/main/java/uk/gov/ons/ctp/common/event/model/Contact.java
@@ -4,21 +4,14 @@ import com.godaddy.logging.LoggingScope;
 import com.godaddy.logging.Scope;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
 @Data
+@EqualsAndHashCode(callSuper = true)
 @NoArgsConstructor
 @AllArgsConstructor
-public class Contact {
-
-  @LoggingScope(scope = Scope.SKIP)
-  private String title;
-
-  @LoggingScope(scope = Scope.SKIP)
-  private String forename;
-
-  @LoggingScope(scope = Scope.SKIP)
-  private String surname;
+public class Contact extends ContactCompact {
 
   @LoggingScope(scope = Scope.SKIP)
   private String telNo;

--- a/src/main/java/uk/gov/ons/ctp/common/event/model/ContactCompact.java
+++ b/src/main/java/uk/gov/ons/ctp/common/event/model/ContactCompact.java
@@ -1,0 +1,22 @@
+package uk.gov.ons.ctp.common.event.model;
+
+import com.godaddy.logging.LoggingScope;
+import com.godaddy.logging.Scope;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ContactCompact {
+
+  @LoggingScope(scope = Scope.SKIP)
+  private String title;
+
+  @LoggingScope(scope = Scope.SKIP)
+  private String forename;
+
+  @LoggingScope(scope = Scope.SKIP)
+  private String surname;
+}

--- a/src/main/java/uk/gov/ons/ctp/common/event/model/RespondentRefusalDetails.java
+++ b/src/main/java/uk/gov/ons/ctp/common/event/model/RespondentRefusalDetails.java
@@ -1,9 +1,12 @@
 package uk.gov.ons.ctp.common.event.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Data
 @NoArgsConstructor
@@ -14,10 +17,27 @@ public class RespondentRefusalDetails implements EventPayload {
   private String agentId;
   private String callId;
 
-  @JsonProperty(value = "isHouseholder")
+  @Getter(AccessLevel.NONE)
+  @Setter(AccessLevel.NONE)
   private boolean isHouseholder;
 
   private CollectionCaseCompact collectionCase;
   private ContactCompact contact;
   private AddressCompact address;
+
+  // The explicit get and set methods workaround a problem caused by the interaction of Lombok and
+  // Jackson.
+  // By default lombok creates an isHouseholder() method, but then Jackson serialises this without
+  // the 'is' part.
+  // BTW, a JsonProperty annotation still leaves the isHouseholder() method visible, so the
+  // generated Json contains a 'isHouseholder' and a 'householder' field.
+  @JsonProperty(value = "isHouseholder")
+  public boolean isHouseholder() {
+    return isHouseholder;
+  }
+
+  @JsonProperty(value = "isHouseholder")
+  public void setHouseholder(boolean isHouseholder) {
+    this.isHouseholder = isHouseholder;
+  }
 }

--- a/src/main/java/uk/gov/ons/ctp/common/event/model/RespondentRefusalDetails.java
+++ b/src/main/java/uk/gov/ons/ctp/common/event/model/RespondentRefusalDetails.java
@@ -27,8 +27,8 @@ public class RespondentRefusalDetails implements EventPayload {
 
   // The explicit get and set methods workaround a problem caused by the interaction of Lombok and
   // Jackson.
-  // By default lombok creates an isHouseholder() method, but then Jackson serialises this without
-  // the 'is' part.
+  // By default lombok creates an isHouseholder() method, but then Jackson serialises this as
+  // simply 'householder'.
   // BTW, a JsonProperty annotation still leaves the isHouseholder() method visible, so the
   // generated Json contains a 'isHouseholder' and a 'householder' field.
   @JsonProperty(value = "isHouseholder")

--- a/src/main/java/uk/gov/ons/ctp/common/event/model/RespondentRefusalDetails.java
+++ b/src/main/java/uk/gov/ons/ctp/common/event/model/RespondentRefusalDetails.java
@@ -1,5 +1,6 @@
 package uk.gov.ons.ctp.common.event.model;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -10,10 +11,13 @@ import lombok.NoArgsConstructor;
 public class RespondentRefusalDetails implements EventPayload {
 
   private String type;
-  private String report;
   private String agentId;
   private String callId;
+
+  @JsonProperty(value = "isHouseholder")
+  private boolean isHouseholder;
+
   private CollectionCaseCompact collectionCase;
-  private Contact contact;
+  private ContactCompact contact;
   private AddressCompact address;
 }

--- a/src/test/resources/uk/gov/ons/ctp/common/event/PackageFixture.RespondentRefusalDetails.json
+++ b/src/test/resources/uk/gov/ons/ctp/common/event/PackageFixture.RespondentRefusalDetails.json
@@ -1,16 +1,15 @@
 {
   "type" : "EXTRAORDINARY_REFUSAL",
-  "report" : "Description of refusal",
   "agentId" : "x1",
   "callId": "898-NOW",
+  "isHouseholder": "true",
   "collectionCase" : {
     "id" : "18353ceb-28cf-4a64-bee2-c4dc556d1268"
   },
   "contact" : {
     "title" : "Ms",
     "forename" : "jo",
-    "surname" : "smith",
-    "telNo" : "+447890000000"
+    "surname" : "smith"
   },
   "address" : {
     "addressLine1" : "1 main street",


### PR DESCRIPTION
Updates to the contents of a respondent refusal event:

Removed report (for notes & comments)
Removed telephone number (at the cost of needing a new Contact object)
Added isHouseholder flag