### PR TITLE
Cr 1065 play firestore events

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>uk.gov.ons.ctp.integration.common</groupId>
   <artifactId>event-publisher</artifactId>
-  <version>0.0.43-CR1065-SNAPSHOT</version>
+  <version>0.0.43-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>CTP : Integration Event Publisher</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>uk.gov.ons.ctp.integration.common</groupId>
   <artifactId>event-publisher</artifactId>
-  <version>0.0.43-SNAPSHOT</version>
+  <version>0.0.43-CR1065-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>CTP : Integration Event Publisher</name>

--- a/src/main/java/uk/gov/ons/ctp/common/event/EventBuilder.java
+++ b/src/main/java/uk/gov/ons/ctp/common/event/EventBuilder.java
@@ -1,0 +1,404 @@
+package uk.gov.ons.ctp.common.event;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Date;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import uk.gov.ons.ctp.common.event.EventPublisher.Channel;
+import uk.gov.ons.ctp.common.event.EventPublisher.EventType;
+import uk.gov.ons.ctp.common.event.EventPublisher.Source;
+import uk.gov.ons.ctp.common.event.model.AddressModification;
+import uk.gov.ons.ctp.common.event.model.AddressModifiedEvent;
+import uk.gov.ons.ctp.common.event.model.AddressModifiedPayload;
+import uk.gov.ons.ctp.common.event.model.AddressNotValid;
+import uk.gov.ons.ctp.common.event.model.AddressNotValidEvent;
+import uk.gov.ons.ctp.common.event.model.AddressNotValidPayload;
+import uk.gov.ons.ctp.common.event.model.AddressTypeChanged;
+import uk.gov.ons.ctp.common.event.model.AddressTypeChangedEvent;
+import uk.gov.ons.ctp.common.event.model.AddressTypeChangedPayload;
+import uk.gov.ons.ctp.common.event.model.CaseEvent;
+import uk.gov.ons.ctp.common.event.model.CasePayload;
+import uk.gov.ons.ctp.common.event.model.CollectionCase;
+import uk.gov.ons.ctp.common.event.model.EventPayload;
+import uk.gov.ons.ctp.common.event.model.Feedback;
+import uk.gov.ons.ctp.common.event.model.FeedbackEvent;
+import uk.gov.ons.ctp.common.event.model.FeedbackPayload;
+import uk.gov.ons.ctp.common.event.model.FulfilmentPayload;
+import uk.gov.ons.ctp.common.event.model.FulfilmentRequest;
+import uk.gov.ons.ctp.common.event.model.FulfilmentRequestedEvent;
+import uk.gov.ons.ctp.common.event.model.GenericEvent;
+import uk.gov.ons.ctp.common.event.model.Header;
+import uk.gov.ons.ctp.common.event.model.NewAddress;
+import uk.gov.ons.ctp.common.event.model.NewAddressPayload;
+import uk.gov.ons.ctp.common.event.model.NewAddressReportedEvent;
+import uk.gov.ons.ctp.common.event.model.QuestionnaireLinkedDetails;
+import uk.gov.ons.ctp.common.event.model.QuestionnaireLinkedEvent;
+import uk.gov.ons.ctp.common.event.model.QuestionnaireLinkedPayload;
+import uk.gov.ons.ctp.common.event.model.RespondentAuthenticatedEvent;
+import uk.gov.ons.ctp.common.event.model.RespondentAuthenticatedResponse;
+import uk.gov.ons.ctp.common.event.model.RespondentRefusalDetails;
+import uk.gov.ons.ctp.common.event.model.RespondentRefusalEvent;
+import uk.gov.ons.ctp.common.event.model.RespondentRefusalPayload;
+import uk.gov.ons.ctp.common.event.model.SurveyLaunchedEvent;
+import uk.gov.ons.ctp.common.event.model.SurveyLaunchedResponse;
+import uk.gov.ons.ctp.common.event.model.UAC;
+import uk.gov.ons.ctp.common.event.model.UACEvent;
+import uk.gov.ons.ctp.common.event.model.UACPayload;
+import uk.gov.ons.ctp.common.jackson.CustomObjectMapper;
+
+/**
+ * Build objects for the ready for the publisher to send events. The subclasses of the event builder
+ * handle the inconsistent structure of each event object.
+ */
+public abstract class EventBuilder {
+  public static final EventBuilder NONE = new NullEventBuilder();
+  public static final EventBuilder FULFILMENT_REQUESTED = new FulfilmentRequestedBuilder();
+  public static final EventBuilder SURVEY_LAUNCHED = new SurveyLaunchedBuilder();
+  public static final EventBuilder RESPONDENT_AUTHENTICATED = new RespondentAuthenticatedBuilder();
+  public static final EventBuilder CASE_CREATED = new CaseCreatedBuilder();
+  public static final EventBuilder CASE_UPDATED = new CaseUpdatedBuilder();
+  public static final EventBuilder REFUSAL_RECEIVED = new RefusalReceivedBuilder();
+  public static final EventBuilder UAC_CREATED = new UacCreatedBuilder();
+  public static final EventBuilder UAC_UPDATED = new UacUpdatedBuilder();
+  public static final EventBuilder ADDRESS_MODIFIED = new AddressModifiedBuilder();
+  public static final EventBuilder ADDRESS_NOT_VALID = new AddressNotValidBuilder();
+  public static final EventBuilder ADDRESS_TYPE_CHANGED = new AddressTypeChangedBuilder();
+  public static final EventBuilder NEW_ADDRESS_REPORTED = new NewAddressReportedBuilder();
+  public static final EventBuilder FEEDBACK = new FeedbackBuilder();
+  public static final EventBuilder QUESTIONNAIRE_LINKED = new QuestionnaireLinkedBuilder();
+
+  ObjectMapper objectMapper = new CustomObjectMapper();
+
+  abstract GenericEvent create(SendInfo sendInfo);
+
+  /**
+   * Create information required to send the event based on the serialised backup event supplied.
+   *
+   * @param json string of serialised event backup JSON.
+   * @return object containing deserialised payload , source and channel.
+   */
+  abstract SendInfo create(String json);
+
+  <T extends GenericEvent> T deserialiseEventJson(String json, Class<T> clazz) {
+    try {
+      return objectMapper.readValue(json, clazz);
+    } catch (JsonProcessingException e) {
+      throw new EventPublishException(e);
+    }
+  }
+
+  static Header buildHeader(EventType type, Source source, Channel channel) {
+    return Header.builder()
+        .type(type)
+        .source(source)
+        .channel(channel)
+        .dateTime(new Date())
+        .transactionId(UUID.randomUUID().toString())
+        .build();
+  }
+
+  @Data
+  @AllArgsConstructor
+  @Builder
+  public static class SendInfo {
+    private EventPayload payload;
+    private Source source;
+    private Channel channel;
+  }
+
+  SendInfo build(GenericEvent genericEvent, EventPayload payload) {
+    SendInfo info =
+        SendInfo.builder()
+            .payload(payload)
+            .source(genericEvent.getEvent().getSource())
+            .channel(genericEvent.getEvent().getChannel())
+            .build();
+    return info;
+  }
+
+  public static class NullEventBuilder extends EventBuilder {
+    @Override
+    GenericEvent create(SendInfo sendInfo) {
+      return null;
+    }
+
+    @Override
+    SendInfo create(String json) {
+      return null;
+    }
+  }
+
+  public static class FulfilmentRequestedBuilder extends EventBuilder {
+    @Override
+    GenericEvent create(SendInfo sendInfo) {
+      FulfilmentRequestedEvent fulfilmentRequestedEvent = new FulfilmentRequestedEvent();
+      fulfilmentRequestedEvent.setEvent(
+          buildHeader(EventType.FULFILMENT_REQUESTED, sendInfo.getSource(), sendInfo.getChannel()));
+      FulfilmentPayload fulfilmentPayload =
+          new FulfilmentPayload((FulfilmentRequest) sendInfo.getPayload());
+      fulfilmentRequestedEvent.setPayload(fulfilmentPayload);
+      return fulfilmentRequestedEvent;
+    }
+
+    @Override
+    SendInfo create(String json) {
+      GenericEvent genericEvent = deserialiseEventJson(json, FulfilmentRequestedEvent.class);
+      EventPayload payload =
+          ((FulfilmentRequestedEvent) genericEvent).getPayload().getFulfilmentRequest();
+      return build(genericEvent, payload);
+    }
+  }
+
+  public static class SurveyLaunchedBuilder extends EventBuilder {
+    @Override
+    GenericEvent create(SendInfo sendInfo) {
+      SurveyLaunchedEvent surveyLaunchedEvent = new SurveyLaunchedEvent();
+      surveyLaunchedEvent.setEvent(
+          buildHeader(EventType.SURVEY_LAUNCHED, sendInfo.getSource(), sendInfo.getChannel()));
+      surveyLaunchedEvent.getPayload().setResponse((SurveyLaunchedResponse) sendInfo.getPayload());
+      return surveyLaunchedEvent;
+    }
+
+    @Override
+    SendInfo create(String json) {
+      GenericEvent genericEvent = deserialiseEventJson(json, SurveyLaunchedEvent.class);
+      EventPayload payload = ((SurveyLaunchedEvent) genericEvent).getPayload().getResponse();
+      return build(genericEvent, payload);
+    }
+  }
+
+  public static class RespondentAuthenticatedBuilder extends EventBuilder {
+    @Override
+    GenericEvent create(SendInfo sendInfo) {
+      RespondentAuthenticatedEvent respondentAuthenticatedEvent =
+          new RespondentAuthenticatedEvent();
+      respondentAuthenticatedEvent.setEvent(
+          buildHeader(
+              EventType.RESPONDENT_AUTHENTICATED, sendInfo.getSource(), sendInfo.getChannel()));
+      respondentAuthenticatedEvent
+          .getPayload()
+          .setResponse((RespondentAuthenticatedResponse) sendInfo.getPayload());
+      return respondentAuthenticatedEvent;
+    }
+
+    @Override
+    SendInfo create(String json) {
+      GenericEvent genericEvent = deserialiseEventJson(json, RespondentAuthenticatedEvent.class);
+      EventPayload payload =
+          ((RespondentAuthenticatedEvent) genericEvent).getPayload().getResponse();
+      return build(genericEvent, payload);
+    }
+  }
+
+  public abstract static class CaseBuilder extends EventBuilder {
+    @Override
+    GenericEvent create(SendInfo sendInfo) {
+      CaseEvent caseEvent = new CaseEvent();
+      caseEvent.setEvent(buildHeader(type(), sendInfo.getSource(), sendInfo.getChannel()));
+      CasePayload casePayload = new CasePayload((CollectionCase) sendInfo.getPayload());
+      caseEvent.setPayload(casePayload);
+      return caseEvent;
+    }
+
+    @Override
+    SendInfo create(String json) {
+      GenericEvent genericEvent = deserialiseEventJson(json, CaseEvent.class);
+      EventPayload payload = ((CaseEvent) genericEvent).getPayload().getCollectionCase();
+      return build(genericEvent, payload);
+    }
+
+    abstract EventType type();
+  }
+
+  public static class CaseCreatedBuilder extends CaseBuilder {
+    @Override
+    EventType type() {
+      return EventType.CASE_CREATED;
+    }
+  }
+
+  public static class CaseUpdatedBuilder extends CaseBuilder {
+    @Override
+    EventType type() {
+      return EventType.CASE_UPDATED;
+    }
+  }
+
+  public static class RefusalReceivedBuilder extends EventBuilder {
+    @Override
+    GenericEvent create(SendInfo sendInfo) {
+      RespondentRefusalEvent respondentRefusalEvent = new RespondentRefusalEvent();
+      respondentRefusalEvent.setEvent(
+          buildHeader(EventType.REFUSAL_RECEIVED, sendInfo.getSource(), sendInfo.getChannel()));
+      RespondentRefusalPayload respondentRefusalPayload =
+          new RespondentRefusalPayload((RespondentRefusalDetails) sendInfo.getPayload());
+      respondentRefusalEvent.setPayload(respondentRefusalPayload);
+      return respondentRefusalEvent;
+    }
+
+    @Override
+    SendInfo create(String json) {
+      GenericEvent genericEvent = deserialiseEventJson(json, RespondentRefusalEvent.class);
+      EventPayload payload = ((RespondentRefusalEvent) genericEvent).getPayload().getRefusal();
+      return build(genericEvent, payload);
+    }
+  }
+
+  public abstract static class UacBuilder extends EventBuilder {
+    @Override
+    GenericEvent create(SendInfo sendInfo) {
+      UACEvent uacEvent = new UACEvent();
+      uacEvent.setEvent(buildHeader(type(), sendInfo.getSource(), sendInfo.getChannel()));
+      UACPayload uacPayload = new UACPayload((UAC) sendInfo.getPayload());
+      uacEvent.setPayload(uacPayload);
+      return uacEvent;
+    }
+
+    @Override
+    SendInfo create(String json) {
+      GenericEvent genericEvent = deserialiseEventJson(json, UACEvent.class);
+      EventPayload payload = ((UACEvent) genericEvent).getPayload().getUac();
+      return build(genericEvent, payload);
+    }
+
+    abstract EventType type();
+  }
+
+  public static class UacCreatedBuilder extends UacBuilder {
+    @Override
+    EventType type() {
+      return EventType.UAC_CREATED;
+    }
+  }
+
+  public static class UacUpdatedBuilder extends UacBuilder {
+    @Override
+    EventType type() {
+      return EventType.UAC_UPDATED;
+    }
+  }
+
+  public static class AddressModifiedBuilder extends EventBuilder {
+    @Override
+    GenericEvent create(SendInfo sendInfo) {
+      AddressModifiedEvent addressModifiedEvent = new AddressModifiedEvent();
+      addressModifiedEvent.setEvent(
+          buildHeader(EventType.ADDRESS_MODIFIED, sendInfo.getSource(), sendInfo.getChannel()));
+      AddressModifiedPayload addressModifiedPayload =
+          new AddressModifiedPayload((AddressModification) sendInfo.getPayload());
+      addressModifiedEvent.setPayload(addressModifiedPayload);
+      return addressModifiedEvent;
+    }
+
+    @Override
+    SendInfo create(String json) {
+      GenericEvent genericEvent = deserialiseEventJson(json, AddressModifiedEvent.class);
+      EventPayload payload =
+          ((AddressModifiedEvent) genericEvent).getPayload().getAddressModification();
+      return build(genericEvent, payload);
+    }
+  }
+
+  public static class AddressNotValidBuilder extends EventBuilder {
+    @Override
+    GenericEvent create(SendInfo sendInfo) {
+      AddressNotValidEvent addrNotValidEvent = new AddressNotValidEvent();
+      addrNotValidEvent.setEvent(
+          buildHeader(EventType.ADDRESS_NOT_VALID, sendInfo.getSource(), sendInfo.getChannel()));
+      AddressNotValidPayload addrNotValidPayload =
+          new AddressNotValidPayload((AddressNotValid) sendInfo.getPayload());
+      addrNotValidEvent.setPayload(addrNotValidPayload);
+      return addrNotValidEvent;
+    }
+
+    @Override
+    SendInfo create(String json) {
+      GenericEvent genericEvent = deserialiseEventJson(json, AddressNotValidEvent.class);
+      EventPayload payload = ((AddressNotValidEvent) genericEvent).getPayload().getInvalidAddress();
+      return build(genericEvent, payload);
+    }
+  }
+
+  public static class AddressTypeChangedBuilder extends EventBuilder {
+    @Override
+    GenericEvent create(SendInfo sendInfo) {
+      AddressTypeChangedEvent addressTypeChangedEvent = new AddressTypeChangedEvent();
+      addressTypeChangedEvent.setEvent(
+          buildHeader(EventType.ADDRESS_TYPE_CHANGED, sendInfo.getSource(), sendInfo.getChannel()));
+      AddressTypeChangedPayload addressTypeChangedPayload =
+          new AddressTypeChangedPayload((AddressTypeChanged) sendInfo.getPayload());
+      addressTypeChangedEvent.setPayload(addressTypeChangedPayload);
+      return addressTypeChangedEvent;
+    }
+
+    @Override
+    SendInfo create(String json) {
+      GenericEvent genericEvent = deserialiseEventJson(json, AddressTypeChangedEvent.class);
+      EventPayload payload =
+          ((AddressTypeChangedEvent) genericEvent).getPayload().getAddressTypeChange();
+      return build(genericEvent, payload);
+    }
+  }
+
+  public static class NewAddressReportedBuilder extends EventBuilder {
+    @Override
+    GenericEvent create(SendInfo sendInfo) {
+      NewAddressReportedEvent newAddressReportedEvent = new NewAddressReportedEvent();
+      newAddressReportedEvent.setEvent(
+          buildHeader(EventType.NEW_ADDRESS_REPORTED, sendInfo.getSource(), sendInfo.getChannel()));
+      NewAddressPayload newAddressPayload =
+          new NewAddressPayload((NewAddress) sendInfo.getPayload());
+      newAddressReportedEvent.setPayload(newAddressPayload);
+      return newAddressReportedEvent;
+    }
+
+    @Override
+    SendInfo create(String json) {
+      GenericEvent genericEvent = deserialiseEventJson(json, NewAddressReportedEvent.class);
+      EventPayload payload = ((NewAddressReportedEvent) genericEvent).getPayload().getNewAddress();
+      return build(genericEvent, payload);
+    }
+  }
+
+  public static class FeedbackBuilder extends EventBuilder {
+    @Override
+    GenericEvent create(SendInfo sendInfo) {
+      FeedbackEvent feedbackEvent = new FeedbackEvent();
+      feedbackEvent.setEvent(
+          buildHeader(EventType.FEEDBACK, sendInfo.getSource(), sendInfo.getChannel()));
+      FeedbackPayload feedbackPayload = new FeedbackPayload((Feedback) sendInfo.getPayload());
+      feedbackEvent.setPayload(feedbackPayload);
+      return feedbackEvent;
+    }
+
+    @Override
+    SendInfo create(String json) {
+      GenericEvent genericEvent = deserialiseEventJson(json, FeedbackEvent.class);
+      EventPayload payload = ((FeedbackEvent) genericEvent).getPayload().getFeedback();
+      return build(genericEvent, payload);
+    }
+  }
+
+  public static class QuestionnaireLinkedBuilder extends EventBuilder {
+    @Override
+    GenericEvent create(SendInfo sendInfo) {
+      QuestionnaireLinkedEvent questionnaireLinkedEvent = new QuestionnaireLinkedEvent();
+      questionnaireLinkedEvent.setEvent(
+          buildHeader(EventType.QUESTIONNAIRE_LINKED, sendInfo.getSource(), sendInfo.getChannel()));
+      QuestionnaireLinkedPayload questionnaireLinkedPayload =
+          new QuestionnaireLinkedPayload((QuestionnaireLinkedDetails) sendInfo.getPayload());
+      questionnaireLinkedEvent.setPayload(questionnaireLinkedPayload);
+      return questionnaireLinkedEvent;
+    }
+
+    @Override
+    SendInfo create(String json) {
+      GenericEvent genericEvent = deserialiseEventJson(json, QuestionnaireLinkedEvent.class);
+      EventPayload payload = ((QuestionnaireLinkedEvent) genericEvent).getPayload().getUac();
+      return build(genericEvent, payload);
+    }
+  }
+}

--- a/src/main/java/uk/gov/ons/ctp/common/event/EventBuilder.java
+++ b/src/main/java/uk/gov/ons/ctp/common/event/EventBuilder.java
@@ -72,6 +72,12 @@ public abstract class EventBuilder {
 
   ObjectMapper objectMapper = new CustomObjectMapper();
 
+  /**
+   * Create event ready for send.
+   *
+   * @param sendInfo object containing payload , source and channel.
+   * @return event
+   */
   abstract GenericEvent create(SendInfo sendInfo);
 
   /**
@@ -193,11 +199,12 @@ public abstract class EventBuilder {
     }
   }
 
-  public abstract static class CaseBuilder extends EventBuilder {
+  public static class CaseCreatedBuilder extends EventBuilder {
     @Override
     GenericEvent create(SendInfo sendInfo) {
       CaseEvent caseEvent = new CaseEvent();
-      caseEvent.setEvent(buildHeader(type(), sendInfo.getSource(), sendInfo.getChannel()));
+      caseEvent.setEvent(
+          buildHeader(EventType.CASE_CREATED, sendInfo.getSource(), sendInfo.getChannel()));
       CasePayload casePayload = new CasePayload((CollectionCase) sendInfo.getPayload());
       caseEvent.setPayload(casePayload);
       return caseEvent;
@@ -209,21 +216,24 @@ public abstract class EventBuilder {
       EventPayload payload = ((CaseEvent) genericEvent).getPayload().getCollectionCase();
       return build(genericEvent, payload);
     }
-
-    abstract EventType type();
   }
 
-  public static class CaseCreatedBuilder extends CaseBuilder {
+  public static class CaseUpdatedBuilder extends EventBuilder {
     @Override
-    EventType type() {
-      return EventType.CASE_CREATED;
+    GenericEvent create(SendInfo sendInfo) {
+      CaseEvent caseEvent = new CaseEvent();
+      caseEvent.setEvent(
+          buildHeader(EventType.CASE_UPDATED, sendInfo.getSource(), sendInfo.getChannel()));
+      CasePayload casePayload = new CasePayload((CollectionCase) sendInfo.getPayload());
+      caseEvent.setPayload(casePayload);
+      return caseEvent;
     }
-  }
 
-  public static class CaseUpdatedBuilder extends CaseBuilder {
     @Override
-    EventType type() {
-      return EventType.CASE_UPDATED;
+    SendInfo create(String json) {
+      GenericEvent genericEvent = deserialiseEventJson(json, CaseEvent.class);
+      EventPayload payload = ((CaseEvent) genericEvent).getPayload().getCollectionCase();
+      return build(genericEvent, payload);
     }
   }
 
@@ -247,11 +257,12 @@ public abstract class EventBuilder {
     }
   }
 
-  public abstract static class UacBuilder extends EventBuilder {
+  public static class UacCreatedBuilder extends EventBuilder {
     @Override
     GenericEvent create(SendInfo sendInfo) {
       UACEvent uacEvent = new UACEvent();
-      uacEvent.setEvent(buildHeader(type(), sendInfo.getSource(), sendInfo.getChannel()));
+      uacEvent.setEvent(
+          buildHeader(EventType.UAC_CREATED, sendInfo.getSource(), sendInfo.getChannel()));
       UACPayload uacPayload = new UACPayload((UAC) sendInfo.getPayload());
       uacEvent.setPayload(uacPayload);
       return uacEvent;
@@ -263,21 +274,24 @@ public abstract class EventBuilder {
       EventPayload payload = ((UACEvent) genericEvent).getPayload().getUac();
       return build(genericEvent, payload);
     }
-
-    abstract EventType type();
   }
 
-  public static class UacCreatedBuilder extends UacBuilder {
+  public static class UacUpdatedBuilder extends EventBuilder {
     @Override
-    EventType type() {
-      return EventType.UAC_CREATED;
+    GenericEvent create(SendInfo sendInfo) {
+      UACEvent uacEvent = new UACEvent();
+      uacEvent.setEvent(
+          buildHeader(EventType.UAC_UPDATED, sendInfo.getSource(), sendInfo.getChannel()));
+      UACPayload uacPayload = new UACPayload((UAC) sendInfo.getPayload());
+      uacEvent.setPayload(uacPayload);
+      return uacEvent;
     }
-  }
 
-  public static class UacUpdatedBuilder extends UacBuilder {
     @Override
-    EventType type() {
-      return EventType.UAC_UPDATED;
+    SendInfo create(String json) {
+      GenericEvent genericEvent = deserialiseEventJson(json, UACEvent.class);
+      EventPayload payload = ((UACEvent) genericEvent).getPayload().getUac();
+      return build(genericEvent, payload);
     }
   }
 

--- a/src/main/java/uk/gov/ons/ctp/common/event/EventBuilder.java
+++ b/src/main/java/uk/gov/ons/ctp/common/event/EventBuilder.java
@@ -50,8 +50,8 @@ import uk.gov.ons.ctp.common.event.model.UACPayload;
 import uk.gov.ons.ctp.common.jackson.CustomObjectMapper;
 
 /**
- * Build objects for the ready for the publisher to send events. The subclasses of the event builder
- * handle the inconsistent structure of each event object.
+ * Build objects ready for the publisher to send events. The subclasses of the event builder handle
+ * the inconsistent structure of each event object.
  */
 public abstract class EventBuilder {
   public static final EventBuilder NONE = new NullEventBuilder();

--- a/src/main/java/uk/gov/ons/ctp/common/event/EventPublisher.java
+++ b/src/main/java/uk/gov/ons/ctp/common/event/EventPublisher.java
@@ -364,10 +364,12 @@ public class EventPublisher {
       sender.sendEvent(routingKey, genericEvent);
       log.with("eventType", eventType).with("routingKey", routingKey).debug("Have sent message");
     } catch (Exception e) {
-      // diff sender impls may send diff exceptions
-      log.with("eventType", eventType).with("routingKey", routingKey).error("Failed to send event");
+      boolean backup = eventPersistence != null;
+      log.with("eventType", eventType)
+          .with("routingKey", routingKey)
+          .error("Failed to send event {}", backup ? ", but will now backup to firestore" : "");
 
-      if (eventPersistence == null) {
+      if (!backup) {
         throw new EventPublishException("Rabbit failed to send event", e);
       }
 

--- a/src/main/java/uk/gov/ons/ctp/common/event/EventPublisher.java
+++ b/src/main/java/uk/gov/ons/ctp/common/event/EventPublisher.java
@@ -209,16 +209,18 @@ public class EventPublisher {
    * Send a backup event that would have previously been stored in cloud data storage.
    *
    * @param event backup event , typically recovered from firestore.
+   * @return String UUID transaction Id for event
    */
-  public void send(EventBackupData event) {
+  public String sendEvent(EventBackupData event) {
     EventType type = event.getEventType();
     SendInfo sendInfo = type.getBuilder().create(event.getEvent());
     if (sendInfo == null) {
       log.error("Unrecognised event type {}", type);
-      throw new RuntimeException("Unknown event: " + type);
+      throw new UnsupportedOperationException("Unknown event: " + type);
     }
     String transactionId = doSendEvent(type, sendInfo);
     log.debug("Sent {} with transactionId {}", event.getEventType(), transactionId);
+    return transactionId;
   }
 
   private String doSendEvent(EventType eventType, SendInfo sendInfo) {
@@ -246,7 +248,7 @@ public class EventPublisher {
 
     GenericEvent genericEvent = eventType.getBuilder().create(sendInfo);
     if (genericEvent == null) {
-      log.with("eventType", eventType).error("Routing key for eventType not configured");
+      log.with("eventType", eventType).error("Payload for eventType not configured");
       String errorMessage =
           payload.getClass().getName() + " for EventType '" + eventType + "' not supported yet";
       throw new UnsupportedOperationException(errorMessage);

--- a/src/main/java/uk/gov/ons/ctp/common/event/EventPublisher.java
+++ b/src/main/java/uk/gov/ons/ctp/common/event/EventPublisher.java
@@ -3,47 +3,24 @@ package uk.gov.ons.ctp.common.event;
 import com.godaddy.logging.Logger;
 import com.godaddy.logging.LoggerFactory;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.List;
-import java.util.UUID;
 import lombok.Getter;
+import uk.gov.ons.ctp.common.event.EventBuilder.SendInfo;
 import uk.gov.ons.ctp.common.event.model.AddressModification;
-import uk.gov.ons.ctp.common.event.model.AddressModifiedEvent;
-import uk.gov.ons.ctp.common.event.model.AddressModifiedPayload;
 import uk.gov.ons.ctp.common.event.model.AddressNotValid;
-import uk.gov.ons.ctp.common.event.model.AddressNotValidEvent;
-import uk.gov.ons.ctp.common.event.model.AddressNotValidPayload;
 import uk.gov.ons.ctp.common.event.model.AddressTypeChanged;
-import uk.gov.ons.ctp.common.event.model.AddressTypeChangedEvent;
-import uk.gov.ons.ctp.common.event.model.AddressTypeChangedPayload;
-import uk.gov.ons.ctp.common.event.model.CaseEvent;
-import uk.gov.ons.ctp.common.event.model.CasePayload;
 import uk.gov.ons.ctp.common.event.model.CollectionCase;
 import uk.gov.ons.ctp.common.event.model.EventPayload;
 import uk.gov.ons.ctp.common.event.model.Feedback;
-import uk.gov.ons.ctp.common.event.model.FeedbackEvent;
-import uk.gov.ons.ctp.common.event.model.FeedbackPayload;
-import uk.gov.ons.ctp.common.event.model.FulfilmentPayload;
 import uk.gov.ons.ctp.common.event.model.FulfilmentRequest;
-import uk.gov.ons.ctp.common.event.model.FulfilmentRequestedEvent;
 import uk.gov.ons.ctp.common.event.model.GenericEvent;
-import uk.gov.ons.ctp.common.event.model.Header;
 import uk.gov.ons.ctp.common.event.model.NewAddress;
-import uk.gov.ons.ctp.common.event.model.NewAddressPayload;
-import uk.gov.ons.ctp.common.event.model.NewAddressReportedEvent;
 import uk.gov.ons.ctp.common.event.model.QuestionnaireLinkedDetails;
-import uk.gov.ons.ctp.common.event.model.QuestionnaireLinkedEvent;
-import uk.gov.ons.ctp.common.event.model.QuestionnaireLinkedPayload;
-import uk.gov.ons.ctp.common.event.model.RespondentAuthenticatedEvent;
 import uk.gov.ons.ctp.common.event.model.RespondentAuthenticatedResponse;
 import uk.gov.ons.ctp.common.event.model.RespondentRefusalDetails;
-import uk.gov.ons.ctp.common.event.model.RespondentRefusalEvent;
-import uk.gov.ons.ctp.common.event.model.RespondentRefusalPayload;
-import uk.gov.ons.ctp.common.event.model.SurveyLaunchedEvent;
 import uk.gov.ons.ctp.common.event.model.SurveyLaunchedResponse;
 import uk.gov.ons.ctp.common.event.model.UAC;
-import uk.gov.ons.ctp.common.event.model.UACEvent;
-import uk.gov.ons.ctp.common.event.model.UACPayload;
+import uk.gov.ons.ctp.common.event.persistence.EventBackupData;
 import uk.gov.ons.ctp.common.event.persistence.EventPersistence;
 
 /** Service responsible for the publication of events. */
@@ -103,34 +80,39 @@ public class EventPublisher {
 
   @Getter
   public enum EventType {
-    ADDRESS_MODIFIED(AddressModification.class),
-    ADDRESS_NOT_VALID(AddressNotValid.class),
-    ADDRESS_TYPE_CHANGED(AddressTypeChanged.class),
+    ADDRESS_MODIFIED(AddressModification.class, EventBuilder.ADDRESS_MODIFIED),
+    ADDRESS_NOT_VALID(AddressNotValid.class, EventBuilder.ADDRESS_NOT_VALID),
+    ADDRESS_TYPE_CHANGED(AddressTypeChanged.class, EventBuilder.ADDRESS_TYPE_CHANGED),
     APPOINTMENT_REQUESTED,
-    CASE_CREATED(CollectionCase.class),
-    CASE_UPDATED(CollectionCase.class),
+    CASE_CREATED(CollectionCase.class, EventBuilder.CASE_CREATED),
+    CASE_UPDATED(CollectionCase.class, EventBuilder.CASE_UPDATED),
     CCS_PROPERTY_LISTED,
     FIELD_CASE_UPDATED,
     FULFILMENT_CONFIRMED,
-    FULFILMENT_REQUESTED(FulfilmentRequest.class),
-    NEW_ADDRESS_REPORTED(NewAddress.class),
-    QUESTIONNAIRE_LINKED(QuestionnaireLinkedDetails.class),
-    REFUSAL_RECEIVED(RespondentRefusalDetails.class),
-    RESPONDENT_AUTHENTICATED(RespondentAuthenticatedResponse.class),
+    FULFILMENT_REQUESTED(FulfilmentRequest.class, EventBuilder.FULFILMENT_REQUESTED),
+    NEW_ADDRESS_REPORTED(NewAddress.class, EventBuilder.NEW_ADDRESS_REPORTED),
+    QUESTIONNAIRE_LINKED(QuestionnaireLinkedDetails.class, EventBuilder.QUESTIONNAIRE_LINKED),
+    REFUSAL_RECEIVED(RespondentRefusalDetails.class, EventBuilder.REFUSAL_RECEIVED),
+    RESPONDENT_AUTHENTICATED(
+        RespondentAuthenticatedResponse.class, EventBuilder.RESPONDENT_AUTHENTICATED),
     RESPONSE_RECEIVED,
     SAMPLE_UNIT_VALIDATED,
-    SURVEY_LAUNCHED(SurveyLaunchedResponse.class),
-    UAC_CREATED(UAC.class),
-    UAC_UPDATED(UAC.class),
+    SURVEY_LAUNCHED(SurveyLaunchedResponse.class, EventBuilder.SURVEY_LAUNCHED),
+    UAC_CREATED(UAC.class, EventBuilder.UAC_CREATED),
+    UAC_UPDATED(UAC.class, EventBuilder.UAC_UPDATED),
     UNDELIVERED_MAIL_REPORTED,
-    FEEDBACK(Feedback.class);
+    FEEDBACK(Feedback.class, EventBuilder.FEEDBACK);
 
     private Class<? extends EventPayload> payloadType;
+    private EventBuilder builder;
 
-    private EventType() {}
+    private EventType() {
+      this.builder = EventBuilder.NONE;
+    }
 
-    private EventType(Class<? extends EventPayload> payloadType) {
+    private EventType(Class<? extends EventPayload> payloadType, EventBuilder builder) {
       this.payloadType = payloadType;
+      this.builder = builder;
     }
   }
 
@@ -216,15 +198,31 @@ public class EventPublisher {
 
     log.with(eventType).with(source).with(channel).with(payload).debug("Enter sendEvent()");
 
-    String transactionId = doSendEvent(eventType, source, channel, payload);
+    String transactionId = doSendEvent(eventType, new SendInfo(payload, source, channel));
 
     log.with(eventType).with(source).with(channel).with(payload).debug("Exit sendEvent()");
 
     return transactionId;
   }
 
-  private String doSendEvent(
-      EventType eventType, Source source, Channel channel, EventPayload payload) {
+  /**
+   * Send a backup event that would have previously been stored in cloud data storage.
+   *
+   * @param event backup event , typically recovered from firestore.
+   */
+  public void send(EventBackupData event) {
+    EventType type = event.getEventType();
+    SendInfo sendInfo = type.getBuilder().create(event.getEvent());
+    if (sendInfo == null) {
+      log.error("Unrecognised event type {}", type);
+      throw new RuntimeException("Unknown event: " + type);
+    }
+    String transactionId = doSendEvent(type, sendInfo);
+    log.debug("Sent {} with transactionId {}", event.getEventType(), transactionId);
+  }
+
+  private String doSendEvent(EventType eventType, SendInfo sendInfo) {
+    EventPayload payload = sendInfo.getPayload();
 
     if (!payload.getClass().equals(eventType.getPayloadType())) {
       log.with("payloadType", payload.getClass())
@@ -246,117 +244,12 @@ public class EventPublisher {
       throw new UnsupportedOperationException(errorMessage);
     }
 
-    GenericEvent genericEvent = null;
-    switch (eventType) {
-      case FULFILMENT_REQUESTED:
-        FulfilmentRequestedEvent fulfilmentRequestedEvent = new FulfilmentRequestedEvent();
-        fulfilmentRequestedEvent.setEvent(buildHeader(eventType, source, channel));
-        FulfilmentPayload fulfilmentPayload = new FulfilmentPayload((FulfilmentRequest) payload);
-        fulfilmentRequestedEvent.setPayload(fulfilmentPayload);
-        genericEvent = fulfilmentRequestedEvent;
-        break;
-
-      case SURVEY_LAUNCHED:
-        SurveyLaunchedEvent surveyLaunchedEvent = new SurveyLaunchedEvent();
-        surveyLaunchedEvent.setEvent(buildHeader(eventType, source, channel));
-        surveyLaunchedEvent.getPayload().setResponse((SurveyLaunchedResponse) payload);
-        genericEvent = surveyLaunchedEvent;
-        break;
-
-      case RESPONDENT_AUTHENTICATED:
-        RespondentAuthenticatedEvent respondentAuthenticatedEvent =
-            new RespondentAuthenticatedEvent();
-        respondentAuthenticatedEvent.setEvent(buildHeader(eventType, source, channel));
-        respondentAuthenticatedEvent
-            .getPayload()
-            .setResponse((RespondentAuthenticatedResponse) payload);
-        genericEvent = respondentAuthenticatedEvent;
-        break;
-
-      case CASE_CREATED:
-      case CASE_UPDATED:
-        CaseEvent caseEvent = new CaseEvent();
-        caseEvent.setEvent(buildHeader(eventType, source, channel));
-        CasePayload casePayload = new CasePayload((CollectionCase) payload);
-        caseEvent.setPayload(casePayload);
-        genericEvent = caseEvent;
-        break;
-
-      case REFUSAL_RECEIVED:
-        RespondentRefusalEvent respondentRefusalEvent = new RespondentRefusalEvent();
-        respondentRefusalEvent.setEvent(buildHeader(eventType, source, channel));
-        RespondentRefusalPayload respondentRefusalPayload =
-            new RespondentRefusalPayload((RespondentRefusalDetails) payload);
-        respondentRefusalEvent.setPayload(respondentRefusalPayload);
-        genericEvent = respondentRefusalEvent;
-        break;
-
-      case UAC_CREATED:
-      case UAC_UPDATED:
-        UACEvent uacEvent = new UACEvent();
-        uacEvent.setEvent(buildHeader(eventType, source, channel));
-        UACPayload uacPayload = new UACPayload((UAC) payload);
-        uacEvent.setPayload(uacPayload);
-        genericEvent = uacEvent;
-        break;
-
-      case ADDRESS_MODIFIED:
-        AddressModifiedEvent addressModifiedEvent = new AddressModifiedEvent();
-        addressModifiedEvent.setEvent(buildHeader(eventType, source, channel));
-        AddressModifiedPayload addressModifiedPayload =
-            new AddressModifiedPayload((AddressModification) payload);
-        addressModifiedEvent.setPayload(addressModifiedPayload);
-        genericEvent = addressModifiedEvent;
-        break;
-
-      case ADDRESS_NOT_VALID:
-        AddressNotValidEvent addrNotValidEvent = new AddressNotValidEvent();
-        addrNotValidEvent.setEvent(buildHeader(eventType, source, channel));
-        AddressNotValidPayload addrNotValidPayload =
-            new AddressNotValidPayload((AddressNotValid) payload);
-        addrNotValidEvent.setPayload(addrNotValidPayload);
-        genericEvent = addrNotValidEvent;
-        break;
-
-      case ADDRESS_TYPE_CHANGED:
-        AddressTypeChangedEvent addressTypeChangedEvent = new AddressTypeChangedEvent();
-        addressTypeChangedEvent.setEvent(buildHeader(eventType, source, channel));
-        AddressTypeChangedPayload addressTypeChangedPayload =
-            new AddressTypeChangedPayload((AddressTypeChanged) payload);
-        addressTypeChangedEvent.setPayload(addressTypeChangedPayload);
-        genericEvent = addressTypeChangedEvent;
-        break;
-
-      case NEW_ADDRESS_REPORTED:
-        NewAddressReportedEvent newAddressReportedEvent = new NewAddressReportedEvent();
-        newAddressReportedEvent.setEvent(buildHeader(eventType, source, channel));
-        NewAddressPayload newAddressPayload = new NewAddressPayload((NewAddress) payload);
-        newAddressReportedEvent.setPayload(newAddressPayload);
-        genericEvent = newAddressReportedEvent;
-        break;
-
-      case FEEDBACK:
-        FeedbackEvent feedbackEvent = new FeedbackEvent();
-        feedbackEvent.setEvent(buildHeader(eventType, source, channel));
-        FeedbackPayload feedbackPayload = new FeedbackPayload((Feedback) payload);
-        feedbackEvent.setPayload(feedbackPayload);
-        genericEvent = feedbackEvent;
-        break;
-
-      case QUESTIONNAIRE_LINKED:
-        QuestionnaireLinkedEvent questionnaireLinkedEvent = new QuestionnaireLinkedEvent();
-        questionnaireLinkedEvent.setEvent(buildHeader(eventType, source, channel));
-        QuestionnaireLinkedPayload questionnaireLinkedPayload =
-            new QuestionnaireLinkedPayload((QuestionnaireLinkedDetails) payload);
-        questionnaireLinkedEvent.setPayload(questionnaireLinkedPayload);
-        genericEvent = questionnaireLinkedEvent;
-        break;
-
-      default:
-        log.with("eventType", eventType).error("Routing key for eventType not configured");
-        String errorMessage =
-            payload.getClass().getName() + " for EventType '" + eventType + "' not supported yet";
-        throw new UnsupportedOperationException(errorMessage);
+    GenericEvent genericEvent = eventType.getBuilder().create(sendInfo);
+    if (genericEvent == null) {
+      log.with("eventType", eventType).error("Routing key for eventType not configured");
+      String errorMessage =
+          payload.getClass().getName() + " for EventType '" + eventType + "' not supported yet";
+      throw new UnsupportedOperationException(errorMessage);
     }
 
     try {
@@ -391,15 +284,5 @@ public class EventPublisher {
     }
 
     return genericEvent.getEvent().getTransactionId();
-  }
-
-  private static Header buildHeader(EventType type, Source source, Channel channel) {
-    return Header.builder()
-        .type(type)
-        .source(source)
-        .channel(channel)
-        .dateTime(new Date())
-        .transactionId(UUID.randomUUID().toString())
-        .build();
   }
 }

--- a/src/main/java/uk/gov/ons/ctp/common/event/EventPublisher.java
+++ b/src/main/java/uk/gov/ons/ctp/common/event/EventPublisher.java
@@ -376,7 +376,7 @@ public class EventPublisher {
 
       // Save event to persistent store
       try {
-        eventPersistence.persistEvent(eventType, routingKey, genericEvent);
+        eventPersistence.persistEvent(eventType, genericEvent);
         log.with("eventType", eventType)
             .with("routingKey", routingKey)
             .info("Event data saved to persistent store");

--- a/src/main/java/uk/gov/ons/ctp/common/event/EventPublisher.java
+++ b/src/main/java/uk/gov/ons/ctp/common/event/EventPublisher.java
@@ -365,10 +365,7 @@ public class EventPublisher {
       log.with("eventType", eventType).with("routingKey", routingKey).debug("Have sent message");
     } catch (Exception e) {
       // diff sender impls may send diff exceptions
-      log.with("eventType", eventType)
-          .with("routingKey", routingKey)
-          .with("exception", e)
-          .error("Failed to send event");
+      log.with("eventType", eventType).with("routingKey", routingKey).error("Failed to send event");
 
       if (eventPersistence == null) {
         throw new EventPublishException("Rabbit failed to send event", e);

--- a/src/main/java/uk/gov/ons/ctp/common/event/persistence/EventBackupData.java
+++ b/src/main/java/uk/gov/ons/ctp/common/event/persistence/EventBackupData.java
@@ -5,8 +5,6 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import uk.gov.ons.ctp.common.event.EventPublisher.EventType;
-import uk.gov.ons.ctp.common.event.EventPublisher.RoutingKey;
-import uk.gov.ons.ctp.common.event.model.GenericEvent;
 
 /**
  * This class holds data about an event which Rabbit failed to send.
@@ -22,6 +20,6 @@ public class EventBackupData {
   private EventType eventType;
   private Long messageFailureDateTimeInMillis;
   private Long messageSentDateTimeInMillis;
-  private RoutingKey routingKey;
-  private GenericEvent genericEvent;
+  private String id;
+  private String event;
 }

--- a/src/main/java/uk/gov/ons/ctp/common/event/persistence/EventPersistence.java
+++ b/src/main/java/uk/gov/ons/ctp/common/event/persistence/EventPersistence.java
@@ -2,11 +2,9 @@ package uk.gov.ons.ctp.common.event.persistence;
 
 import uk.gov.ons.ctp.common.error.CTPException;
 import uk.gov.ons.ctp.common.event.EventPublisher.EventType;
-import uk.gov.ons.ctp.common.event.EventPublisher.RoutingKey;
 import uk.gov.ons.ctp.common.event.model.GenericEvent;
 
 public interface EventPersistence {
 
-  void persistEvent(EventType eventType, RoutingKey routingKey, GenericEvent genericEvent)
-      throws CTPException;
+  void persistEvent(EventType eventType, GenericEvent genericEvent) throws CTPException;
 }

--- a/src/main/java/uk/gov/ons/ctp/common/event/persistence/FirestoreEventPersistence.java
+++ b/src/main/java/uk/gov/ons/ctp/common/event/persistence/FirestoreEventPersistence.java
@@ -1,5 +1,6 @@
 package uk.gov.ons.ctp.common.event.persistence;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.godaddy.logging.Logger;
 import com.godaddy.logging.LoggerFactory;
 import javax.annotation.PostConstruct;
@@ -8,9 +9,10 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import uk.gov.ons.ctp.common.cloud.RetryableCloudDataStore;
 import uk.gov.ons.ctp.common.error.CTPException;
+import uk.gov.ons.ctp.common.event.EventPublishException;
 import uk.gov.ons.ctp.common.event.EventPublisher.EventType;
-import uk.gov.ons.ctp.common.event.EventPublisher.RoutingKey;
 import uk.gov.ons.ctp.common.event.model.GenericEvent;
+import uk.gov.ons.ctp.common.jackson.CustomObjectMapper;
 
 /**
  * This class saves details about an event which Rabbit failed to sent into a Firestore collection.
@@ -20,7 +22,8 @@ public class FirestoreEventPersistence implements EventPersistence {
 
   private static final Logger log = LoggerFactory.getLogger(FirestoreEventPersistence.class);
 
-  @Autowired private RetryableCloudDataStore cloudDataStore;
+  private RetryableCloudDataStore cloudDataStore;
+  private CustomObjectMapper objectMapper;
 
   @Value("${GOOGLE_CLOUD_PROJECT}")
   String gcpProject;
@@ -35,16 +38,32 @@ public class FirestoreEventPersistence implements EventPersistence {
     eventBackupSchema = gcpProject + "-" + eventBackupSchemaName.toLowerCase();
   }
 
+  @Autowired
+  public FirestoreEventPersistence(
+      RetryableCloudDataStore cloudDataStore, CustomObjectMapper objectMapper) {
+    this.cloudDataStore = cloudDataStore;
+    this.objectMapper = objectMapper;
+  }
+
+  private String serialise(Object obj) {
+    try {
+      return objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(obj);
+    } catch (JsonProcessingException e) {
+      throw new EventPublishException("Failed to serialise event to JSON", e);
+    }
+  }
+
   @Override
-  public void persistEvent(EventType eventType, RoutingKey routingKey, GenericEvent genericEvent)
-      throws CTPException {
-    log.with("id", routingKey.getKey()).debug("Storing event data in Firestore");
+  public void persistEvent(EventType eventType, GenericEvent genericEvent) throws CTPException {
+    String id = genericEvent.getEvent().getTransactionId();
+
+    log.with("id", id).debug("Storing event data in Firestore");
 
     EventBackupData eventData = new EventBackupData();
     eventData.setEventType(eventType);
     eventData.setMessageFailureDateTimeInMillis(System.currentTimeMillis());
-    eventData.setRoutingKey(routingKey);
-    eventData.setGenericEvent(genericEvent);
+    eventData.setId(id);
+    eventData.setEvent(serialise(genericEvent));
 
     cloudDataStore.storeObject(
         eventBackupSchema,
@@ -52,6 +71,6 @@ public class FirestoreEventPersistence implements EventPersistence {
         eventData,
         genericEvent.getEvent().getTransactionId());
 
-    log.with("id", routingKey.getKey()).debug("Stored event data");
+    log.with("id", id).debug("Stored event data");
   }
 }

--- a/src/test/java/uk/gov/ons/ctp/common/event/EventPublisherTest.java
+++ b/src/test/java/uk/gov/ons/ctp/common/event/EventPublisherTest.java
@@ -4,21 +4,29 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Date;
 import java.util.UUID;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.test.util.ReflectionTestUtils;
 import uk.gov.ons.ctp.common.FixtureHelper;
 import uk.gov.ons.ctp.common.event.EventPublisher.Channel;
 import uk.gov.ons.ctp.common.event.EventPublisher.EventType;
@@ -38,6 +46,8 @@ import uk.gov.ons.ctp.common.event.model.FeedbackEvent;
 import uk.gov.ons.ctp.common.event.model.FulfilmentRequest;
 import uk.gov.ons.ctp.common.event.model.FulfilmentRequestedEvent;
 import uk.gov.ons.ctp.common.event.model.GenericEvent;
+import uk.gov.ons.ctp.common.event.model.Header;
+import uk.gov.ons.ctp.common.event.model.NewAddressReportedEvent;
 import uk.gov.ons.ctp.common.event.model.QuestionnaireLinkedDetails;
 import uk.gov.ons.ctp.common.event.model.QuestionnaireLinkedEvent;
 import uk.gov.ons.ctp.common.event.model.RespondentAuthenticatedEvent;
@@ -46,7 +56,10 @@ import uk.gov.ons.ctp.common.event.model.RespondentRefusalDetails;
 import uk.gov.ons.ctp.common.event.model.RespondentRefusalEvent;
 import uk.gov.ons.ctp.common.event.model.SurveyLaunchedEvent;
 import uk.gov.ons.ctp.common.event.model.SurveyLaunchedResponse;
+import uk.gov.ons.ctp.common.event.model.UACEvent;
+import uk.gov.ons.ctp.common.event.persistence.EventBackupData;
 import uk.gov.ons.ctp.common.event.persistence.FirestoreEventPersistence;
+import uk.gov.ons.ctp.common.jackson.CustomObjectMapper;
 
 @RunWith(MockitoJUnitRunner.class)
 public class EventPublisherTest {
@@ -56,34 +69,53 @@ public class EventPublisherTest {
   @Mock private SpringRabbitEventSender sender;
   @Mock private FirestoreEventPersistence eventPersistence;
 
-  private void assertHeader(
-      GenericEvent event,
-      String transactionId,
-      EventType expectedType,
-      Source expectedSource,
-      Channel expectedChannel) {
-    assertEquals(transactionId, event.getEvent().getTransactionId());
-    assertThat(UUID.fromString(event.getEvent().getTransactionId()), instanceOf(UUID.class));
-    assertEquals(expectedType, event.getEvent().getType());
-    assertEquals(expectedSource, event.getEvent().getSource());
-    assertEquals(expectedChannel, event.getEvent().getChannel());
-    assertThat(event.getEvent().getDateTime(), instanceOf(Date.class));
+  ObjectMapper objectMapper = new CustomObjectMapper();
+
+  @Captor private ArgumentCaptor<FulfilmentRequestedEvent> fulfilmentRequestedEventCaptor;
+  @Captor private ArgumentCaptor<RespondentAuthenticatedEvent> respondentAuthenticatedEventCaptor;
+  @Captor private ArgumentCaptor<RespondentRefusalEvent> respondentRefusalEventCaptor;
+  @Captor private ArgumentCaptor<UACEvent> uacEventCaptor;
+  @Captor private ArgumentCaptor<SurveyLaunchedEvent> surveyLaunchedEventCaptor;
+  @Captor private ArgumentCaptor<AddressModifiedEvent> addressModifiedEventCaptor;
+  @Captor private ArgumentCaptor<AddressNotValidEvent> addressNotValidEventCaptor;
+  @Captor private ArgumentCaptor<AddressTypeChangedEvent> addressTypeChangedEventCaptor;
+  @Captor private ArgumentCaptor<CaseEvent> caseEventCaptor;
+  @Captor private ArgumentCaptor<FeedbackEvent> feedbackEventCaptor;
+  @Captor private ArgumentCaptor<NewAddressReportedEvent> newAddressReportedEventCaptor;
+  @Captor private ArgumentCaptor<QuestionnaireLinkedEvent> questionnaireLinkedEventCaptor;
+
+  private Date startOfTestDateTime;
+
+  @Before
+  public void setup() {
+    this.startOfTestDateTime = new Date();
+  }
+
+  @Test
+  public void shouldCreateWithoutEventPersistence() {
+    EventPublisher ep = EventPublisher.createWithoutEventPersistence(sender);
+    assertNull(ReflectionTestUtils.getField(ep, "eventPersistence"));
+    assertEquals(sender, ReflectionTestUtils.getField(ep, "sender"));
+  }
+
+  @Test
+  public void shouldCreateWithEventPersistence() {
+    EventPublisher ep = EventPublisher.createWithEventPersistence(sender, eventPersistence);
+    assertNotNull(ReflectionTestUtils.getField(ep, "eventPersistence"));
+    assertEquals(sender, ReflectionTestUtils.getField(ep, "sender"));
   }
 
   @Test
   public void sendEventSurveyLaunchedPayload() {
     SurveyLaunchedResponse surveyLaunchedResponse = loadJson(SurveyLaunchedResponse[].class);
 
-    ArgumentCaptor<SurveyLaunchedEvent> eventCapture =
-        ArgumentCaptor.forClass(SurveyLaunchedEvent.class);
-
     String transactionId =
         eventPublisher.sendEvent(
             EventType.SURVEY_LAUNCHED, Source.RESPONDENT_HOME, Channel.RH, surveyLaunchedResponse);
 
     RoutingKey routingKey = RoutingKey.forType(EventType.RESPONDENT_AUTHENTICATED);
-    verify(sender, times(1)).sendEvent(eq(routingKey), eventCapture.capture());
-    SurveyLaunchedEvent event = eventCapture.getValue();
+    verify(sender, times(1)).sendEvent(eq(routingKey), surveyLaunchedEventCaptor.capture());
+    SurveyLaunchedEvent event = surveyLaunchedEventCaptor.getValue();
     assertHeader(
         event, transactionId, EventType.SURVEY_LAUNCHED, Source.RESPONDENT_HOME, Channel.RH);
     assertEquals(surveyLaunchedResponse, event.getPayload().getResponse());
@@ -94,9 +126,6 @@ public class EventPublisherTest {
     RespondentAuthenticatedResponse respondentAuthenticatedResponse =
         loadJson(RespondentAuthenticatedResponse[].class);
 
-    ArgumentCaptor<RespondentAuthenticatedEvent> eventCapture =
-        ArgumentCaptor.forClass(RespondentAuthenticatedEvent.class);
-
     String transactionId =
         eventPublisher.sendEvent(
             EventType.RESPONDENT_AUTHENTICATED,
@@ -105,8 +134,9 @@ public class EventPublisherTest {
             respondentAuthenticatedResponse);
 
     RoutingKey routingKey = RoutingKey.forType(EventType.RESPONDENT_AUTHENTICATED);
-    verify(sender, times(1)).sendEvent(eq(routingKey), eventCapture.capture());
-    RespondentAuthenticatedEvent event = eventCapture.getValue();
+    verify(sender, times(1))
+        .sendEvent(eq(routingKey), respondentAuthenticatedEventCaptor.capture());
+    RespondentAuthenticatedEvent event = respondentAuthenticatedEventCaptor.getValue();
 
     assertHeader(
         event,
@@ -121,9 +151,6 @@ public class EventPublisherTest {
   public void sendEventFulfilmentRequestPayload() {
     FulfilmentRequest fulfilmentRequest = loadJson(FulfilmentRequest[].class);
 
-    ArgumentCaptor<FulfilmentRequestedEvent> eventCapture =
-        ArgumentCaptor.forClass(FulfilmentRequestedEvent.class);
-
     String transactionId =
         eventPublisher.sendEvent(
             EventType.FULFILMENT_REQUESTED,
@@ -132,8 +159,8 @@ public class EventPublisherTest {
             fulfilmentRequest);
 
     RoutingKey routingKey = RoutingKey.forType(EventType.FULFILMENT_REQUESTED);
-    verify(sender, times(1)).sendEvent(eq(routingKey), eventCapture.capture());
-    FulfilmentRequestedEvent event = eventCapture.getValue();
+    verify(sender, times(1)).sendEvent(eq(routingKey), fulfilmentRequestedEventCaptor.capture());
+    FulfilmentRequestedEvent event = fulfilmentRequestedEventCaptor.getValue();
 
     assertHeader(
         event,
@@ -148,9 +175,6 @@ public class EventPublisherTest {
   public void sendEventRespondentRefusalDetailsPayload() {
     RespondentRefusalDetails respondentRefusalDetails = loadJson(RespondentRefusalDetails[].class);
 
-    ArgumentCaptor<RespondentRefusalEvent> eventCapture =
-        ArgumentCaptor.forClass(RespondentRefusalEvent.class);
-
     String transactionId =
         eventPublisher.sendEvent(
             EventType.REFUSAL_RECEIVED,
@@ -159,8 +183,8 @@ public class EventPublisherTest {
             respondentRefusalDetails);
 
     RoutingKey routingKey = RoutingKey.forType(EventType.REFUSAL_RECEIVED);
-    verify(sender, times(1)).sendEvent(eq(routingKey), eventCapture.capture());
-    RespondentRefusalEvent event = eventCapture.getValue();
+    verify(sender, times(1)).sendEvent(eq(routingKey), respondentRefusalEventCaptor.capture());
+    RespondentRefusalEvent event = respondentRefusalEventCaptor.getValue();
 
     assertHeader(
         event, transactionId, EventType.REFUSAL_RECEIVED, Source.CONTACT_CENTRE_API, Channel.CC);
@@ -191,16 +215,13 @@ public class EventPublisherTest {
   public void sendEventAddressModificationPayload() {
     AddressModification addressModification = loadJson(AddressModification[].class);
 
-    ArgumentCaptor<AddressModifiedEvent> eventCapture =
-        ArgumentCaptor.forClass(AddressModifiedEvent.class);
-
     String transactionId =
         eventPublisher.sendEvent(
             EventType.ADDRESS_MODIFIED, Source.RESPONDENT_HOME, Channel.RH, addressModification);
 
     RoutingKey routingKey = RoutingKey.forType(EventType.ADDRESS_MODIFIED);
-    verify(sender, times(1)).sendEvent(eq(routingKey), eventCapture.capture());
-    AddressModifiedEvent event = eventCapture.getValue();
+    verify(sender, times(1)).sendEvent(eq(routingKey), addressModifiedEventCaptor.capture());
+    AddressModifiedEvent event = addressModifiedEventCaptor.getValue();
 
     assertHeader(
         event, transactionId, EventType.ADDRESS_MODIFIED, Source.RESPONDENT_HOME, Channel.RH);
@@ -211,16 +232,13 @@ public class EventPublisherTest {
   public void shouldSentAddressNotValid() {
     AddressNotValid payload = loadJson(AddressNotValid[].class);
 
-    ArgumentCaptor<AddressNotValidEvent> eventCapture =
-        ArgumentCaptor.forClass(AddressNotValidEvent.class);
-
     String transactionId =
         eventPublisher.sendEvent(
             EventType.ADDRESS_NOT_VALID, Source.CONTACT_CENTRE_API, Channel.CC, payload);
 
     RoutingKey routingKey = RoutingKey.forType(EventType.ADDRESS_NOT_VALID);
-    verify(sender).sendEvent(eq(routingKey), eventCapture.capture());
-    AddressNotValidEvent event = eventCapture.getValue();
+    verify(sender).sendEvent(eq(routingKey), addressNotValidEventCaptor.capture());
+    AddressNotValidEvent event = addressNotValidEventCaptor.getValue();
 
     assertHeader(
         event, transactionId, EventType.ADDRESS_NOT_VALID, Source.CONTACT_CENTRE_API, Channel.CC);
@@ -230,14 +248,12 @@ public class EventPublisherTest {
   private void assertSendCase(EventType type) {
     CollectionCase payload = loadJson(CollectionCase[].class);
 
-    ArgumentCaptor<CaseEvent> eventCapture = ArgumentCaptor.forClass(CaseEvent.class);
-
     String transactionId =
         eventPublisher.sendEvent(type, Source.CONTACT_CENTRE_API, Channel.CC, payload);
 
     RoutingKey routingKey = RoutingKey.forType(type);
-    verify(sender).sendEvent(eq(routingKey), eventCapture.capture());
-    CaseEvent event = eventCapture.getValue();
+    verify(sender).sendEvent(eq(routingKey), caseEventCaptor.capture());
+    CaseEvent event = caseEventCaptor.getValue();
 
     assertHeader(event, transactionId, type, Source.CONTACT_CENTRE_API, Channel.CC);
     assertEquals(payload, event.getPayload().getCollectionCase());
@@ -256,16 +272,14 @@ public class EventPublisherTest {
   @Test
   public void shouldSendAddressTypeChanged() {
     AddressTypeChanged payload = loadJson(AddressTypeChanged[].class);
-    ArgumentCaptor<AddressTypeChangedEvent> eventCapture =
-        ArgumentCaptor.forClass(AddressTypeChangedEvent.class);
 
     String transactionId =
         eventPublisher.sendEvent(
             EventType.ADDRESS_TYPE_CHANGED, Source.CONTACT_CENTRE_API, Channel.CC, payload);
 
     RoutingKey routingKey = RoutingKey.forType(EventType.ADDRESS_TYPE_CHANGED);
-    verify(sender, times(1)).sendEvent(eq(routingKey), eventCapture.capture());
-    AddressTypeChangedEvent event = eventCapture.getValue();
+    verify(sender, times(1)).sendEvent(eq(routingKey), addressTypeChangedEventCaptor.capture());
+    AddressTypeChangedEvent event = addressTypeChangedEventCaptor.getValue();
 
     assertHeader(
         event,
@@ -276,19 +290,17 @@ public class EventPublisherTest {
     assertEquals(payload, event.getPayload().getAddressTypeChange());
   }
 
-  /** Test event message with FeedbackResponse payload */
   @Test
   public void sendEventFeedbackPayload() {
     Feedback feedbackResponse = loadJson(Feedback[].class);
-    ArgumentCaptor<FeedbackEvent> eventCapture = ArgumentCaptor.forClass(FeedbackEvent.class);
 
     String transactionId =
         eventPublisher.sendEvent(
             EventType.FEEDBACK, Source.RESPONDENT_HOME, Channel.RH, feedbackResponse);
 
     RoutingKey routingKey = RoutingKey.forType(EventType.FEEDBACK);
-    verify(sender, times(1)).sendEvent(eq(routingKey), eventCapture.capture());
-    FeedbackEvent event = eventCapture.getValue();
+    verify(sender, times(1)).sendEvent(eq(routingKey), feedbackEventCaptor.capture());
+    FeedbackEvent event = feedbackEventCaptor.getValue();
 
     assertHeader(event, transactionId, EventType.FEEDBACK, Source.RESPONDENT_HOME, Channel.RH);
     assertEquals(feedbackResponse, event.getPayload().getFeedback());
@@ -298,9 +310,6 @@ public class EventPublisherTest {
   public void sendQuestionnaireLinkedPayload() {
     QuestionnaireLinkedDetails questionnaireLinked = loadJson(QuestionnaireLinkedDetails[].class);
 
-    ArgumentCaptor<QuestionnaireLinkedEvent> eventCapture =
-        ArgumentCaptor.forClass(QuestionnaireLinkedEvent.class);
-
     String transactionId =
         eventPublisher.sendEvent(
             EventType.QUESTIONNAIRE_LINKED,
@@ -309,15 +318,288 @@ public class EventPublisherTest {
             questionnaireLinked);
 
     RoutingKey routingKey = RoutingKey.forType(EventType.QUESTIONNAIRE_LINKED);
-    verify(sender, times(1)).sendEvent(eq(routingKey), eventCapture.capture());
-    QuestionnaireLinkedEvent event = eventCapture.getValue();
+    verify(sender, times(1)).sendEvent(eq(routingKey), questionnaireLinkedEventCaptor.capture());
+    QuestionnaireLinkedEvent event = questionnaireLinkedEventCaptor.getValue();
 
     assertHeader(
         event, transactionId, EventType.QUESTIONNAIRE_LINKED, Source.RESPONDENT_HOME, Channel.RH);
     assertEquals(questionnaireLinked, event.getPayload().getUac());
   }
 
+  @Test(expected = IllegalArgumentException.class)
+  public void shouldRejectSendForMismatchingPayload() {
+    Feedback feedbackResponse = loadJson(Feedback[].class);
+
+    eventPublisher.sendEvent(
+        EventType.SAMPLE_UNIT_VALIDATED, Source.RESPONDENT_HOME, Channel.RH, feedbackResponse);
+  }
+
+  // -- replay send backup event tests ...
+
+  @Test
+  public void shouldReplayOneFulfilmentEvent() throws Exception {
+    FulfilmentRequestedEvent ev = aFulfilmentRequestedEvent();
+    sendBackupEvent(ev);
+
+    RoutingKey routingKey = RoutingKey.forType(EventType.FULFILMENT_REQUESTED);
+    verify(sender).sendEvent(eq(routingKey), fulfilmentRequestedEventCaptor.capture());
+    verifyEventSent(ev, fulfilmentRequestedEventCaptor.getValue());
+  }
+
+  @Test
+  public void shouldReplayOneRepondentAuthenticatedEvent() throws Exception {
+    RespondentAuthenticatedEvent ev = aRespondentAuthenticatedEvent();
+    sendBackupEvent(ev);
+
+    RoutingKey routingKey = RoutingKey.forType(EventType.RESPONDENT_AUTHENTICATED);
+    verify(sender).sendEvent(eq(routingKey), respondentAuthenticatedEventCaptor.capture());
+    verifyEventSent(ev, respondentAuthenticatedEventCaptor.getValue());
+  }
+
+  @Test
+  public void shouldReplayOneRefusalReceivedEvent() throws Exception {
+    RespondentRefusalEvent ev = aRefusalEvent();
+    sendBackupEvent(ev);
+
+    RoutingKey routingKey = RoutingKey.forType(EventType.REFUSAL_RECEIVED);
+    verify(sender).sendEvent(eq(routingKey), respondentRefusalEventCaptor.capture());
+    verifyEventSent(ev, respondentRefusalEventCaptor.getValue());
+  }
+
+  @Test
+  public void shouldReplayOneUacCreatedEvent() throws Exception {
+    UACEvent ev = aUacEvent();
+    ev.getEvent().setType(EventType.UAC_CREATED);
+    sendBackupEvent(ev);
+
+    RoutingKey routingKey = RoutingKey.forType(EventType.UAC_CREATED);
+    verify(sender).sendEvent(eq(routingKey), uacEventCaptor.capture());
+    verifyEventSent(ev, uacEventCaptor.getValue());
+  }
+
+  @Test
+  public void shouldReplayOneUacUpdatedEvent() throws Exception {
+    UACEvent ev = aUacEvent();
+    ev.getEvent().setType(EventType.UAC_UPDATED);
+    sendBackupEvent(ev);
+
+    RoutingKey routingKey = RoutingKey.forType(EventType.UAC_UPDATED);
+    verify(sender).sendEvent(eq(routingKey), uacEventCaptor.capture());
+    verifyEventSent(ev, uacEventCaptor.getValue());
+  }
+
+  @Test
+  public void shouldReplayOneSurveyLaunchedEvent() throws Exception {
+    SurveyLaunchedEvent ev = aSurveyLaunchedEvent();
+    sendBackupEvent(ev);
+
+    RoutingKey routingKey = RoutingKey.forType(EventType.SURVEY_LAUNCHED);
+    verify(sender).sendEvent(eq(routingKey), surveyLaunchedEventCaptor.capture());
+    verifyEventSent(ev, surveyLaunchedEventCaptor.getValue());
+  }
+
+  @Test
+  public void shouldReplayOneAddressModifiedEvent() throws Exception {
+    AddressModifiedEvent ev = anAddressModifedEvent();
+    sendBackupEvent(ev);
+
+    RoutingKey routingKey = RoutingKey.forType(EventType.ADDRESS_MODIFIED);
+    verify(sender).sendEvent(eq(routingKey), addressModifiedEventCaptor.capture());
+    verifyEventSent(ev, addressModifiedEventCaptor.getValue());
+  }
+
+  @Test
+  public void shouldReplayOneAddressNotValidEvent() throws Exception {
+    AddressNotValidEvent ev = anAddressNotValidEvent();
+    sendBackupEvent(ev);
+
+    RoutingKey routingKey = RoutingKey.forType(EventType.ADDRESS_NOT_VALID);
+    verify(sender).sendEvent(eq(routingKey), addressNotValidEventCaptor.capture());
+    verifyEventSent(ev, addressNotValidEventCaptor.getValue());
+  }
+
+  @Test
+  public void shouldReplayOneAddressTypeChangedEvent() throws Exception {
+    AddressTypeChangedEvent ev = anAddressTypeChangedEvent();
+    sendBackupEvent(ev);
+
+    RoutingKey routingKey = RoutingKey.forType(EventType.ADDRESS_TYPE_CHANGED);
+    verify(sender).sendEvent(eq(routingKey), addressTypeChangedEventCaptor.capture());
+    verifyEventSent(ev, addressTypeChangedEventCaptor.getValue());
+  }
+
+  @Test
+  public void shouldReplayOneCaseCreatedEvent() throws Exception {
+    CaseEvent ev = aCaseEvent();
+    ev.getEvent().setType(EventType.CASE_CREATED);
+    sendBackupEvent(ev);
+
+    RoutingKey routingKey = RoutingKey.forType(EventType.CASE_CREATED);
+    verify(sender).sendEvent(eq(routingKey), caseEventCaptor.capture());
+    verifyEventSent(ev, caseEventCaptor.getValue());
+  }
+
+  @Test
+  public void shouldReplayOneCaseUpdatedEvent() throws Exception {
+    CaseEvent ev = aCaseEvent();
+    ev.getEvent().setType(EventType.CASE_UPDATED);
+    sendBackupEvent(ev);
+
+    RoutingKey routingKey = RoutingKey.forType(EventType.CASE_UPDATED);
+    verify(sender).sendEvent(eq(routingKey), caseEventCaptor.capture());
+    verifyEventSent(ev, caseEventCaptor.getValue());
+  }
+
+  @Test
+  public void shouldReplayFeedbackEvent() throws Exception {
+    FeedbackEvent ev = aFeedbackEvent();
+    sendBackupEvent(ev);
+
+    RoutingKey routingKey = RoutingKey.forType(EventType.FEEDBACK);
+    verify(sender).sendEvent(eq(routingKey), feedbackEventCaptor.capture());
+    verifyEventSent(ev, feedbackEventCaptor.getValue());
+  }
+
+  @Test
+  public void shouldReplayNewAddressReportedEvent() throws Exception {
+    NewAddressReportedEvent ev = aNewAddressReportedEvent();
+    sendBackupEvent(ev);
+
+    RoutingKey routingKey = RoutingKey.forType(EventType.NEW_ADDRESS_REPORTED);
+    verify(sender).sendEvent(eq(routingKey), newAddressReportedEventCaptor.capture());
+    verifyEventSent(ev, newAddressReportedEventCaptor.getValue());
+  }
+
+  @Test
+  public void shouldReplayQuestionnaireLinkedEvent() throws Exception {
+    QuestionnaireLinkedEvent ev = aQuestionnaireLinkedEvent();
+    sendBackupEvent(ev);
+
+    RoutingKey routingKey = RoutingKey.forType(EventType.QUESTIONNAIRE_LINKED);
+    verify(sender).sendEvent(eq(routingKey), questionnaireLinkedEventCaptor.capture());
+    verifyEventSent(ev, questionnaireLinkedEventCaptor.getValue());
+  }
+
+  @Test(expected = UnsupportedOperationException.class)
+  public void shouldRejectEventWithoutPayload() throws Exception {
+    QuestionnaireLinkedEvent ev = aQuestionnaireLinkedEvent();
+    ev.getEvent().setType(EventType.SAMPLE_UNIT_VALIDATED);
+    sendBackupEvent(ev);
+  }
+
+  @Test(expected = EventPublishException.class)
+  public void shouldRejectMalformedEventBackupJson() throws Exception {
+    QuestionnaireLinkedEvent ev = aQuestionnaireLinkedEvent();
+    EventBackupData data = createEvent(ev);
+    data.setEvent("xx" + data.getEvent()); // create broken Json
+    eventPublisher.sendEvent(data);
+  }
+
+  // --- helpers
+
+  private void sendBackupEvent(GenericEvent ev) throws Exception {
+    EventBackupData data = createEvent(ev);
+    String txId = eventPublisher.sendEvent(data);
+    assertNotNull(txId);
+  }
+
+  private String serialise(Object obj) {
+    try {
+      return objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(obj);
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException("Failed to serialise event to JSON", e);
+    }
+  }
+
+  private EventBackupData createEvent(GenericEvent event) {
+    long failureTimeMillis = 123L;
+    EventBackupData data = new EventBackupData();
+    data.setId(event.getEvent().getTransactionId());
+    data.setEventType(event.getEvent().getType());
+    data.setMessageFailureDateTimeInMillis(failureTimeMillis);
+    data.setMessageSentDateTimeInMillis(null);
+    data.setEvent(serialise(event));
+    return data;
+  }
+
+  FulfilmentRequestedEvent aFulfilmentRequestedEvent() {
+    return FixtureHelper.loadPackageFixtures(FulfilmentRequestedEvent[].class).get(0);
+  }
+
+  RespondentRefusalEvent aRefusalEvent() {
+    return FixtureHelper.loadPackageFixtures(RespondentRefusalEvent[].class).get(0);
+  }
+
+  RespondentAuthenticatedEvent aRespondentAuthenticatedEvent() {
+    return FixtureHelper.loadPackageFixtures(RespondentAuthenticatedEvent[].class).get(0);
+  }
+
+  UACEvent aUacEvent() {
+    return FixtureHelper.loadPackageFixtures(UACEvent[].class).get(0);
+  }
+
+  SurveyLaunchedEvent aSurveyLaunchedEvent() {
+    return FixtureHelper.loadPackageFixtures(SurveyLaunchedEvent[].class).get(0);
+  }
+
+  AddressModifiedEvent anAddressModifedEvent() {
+    return FixtureHelper.loadPackageFixtures(AddressModifiedEvent[].class).get(0);
+  }
+
+  AddressNotValidEvent anAddressNotValidEvent() {
+    return FixtureHelper.loadPackageFixtures(AddressNotValidEvent[].class).get(0);
+  }
+
+  AddressTypeChangedEvent anAddressTypeChangedEvent() {
+    return FixtureHelper.loadPackageFixtures(AddressTypeChangedEvent[].class).get(0);
+  }
+
+  CaseEvent aCaseEvent() {
+    return FixtureHelper.loadPackageFixtures(CaseEvent[].class).get(0);
+  }
+
+  FeedbackEvent aFeedbackEvent() {
+    return FixtureHelper.loadPackageFixtures(FeedbackEvent[].class).get(0);
+  }
+
+  NewAddressReportedEvent aNewAddressReportedEvent() {
+    return FixtureHelper.loadPackageFixtures(NewAddressReportedEvent[].class).get(0);
+  }
+
+  QuestionnaireLinkedEvent aQuestionnaireLinkedEvent() {
+    return FixtureHelper.loadPackageFixtures(QuestionnaireLinkedEvent[].class).get(0);
+  }
+
   private <T> T loadJson(Class<T[]> clazz) {
     return FixtureHelper.loadPackageFixtures(clazz).get(0);
+  }
+
+  private void assertHeader(
+      GenericEvent event,
+      String transactionId,
+      EventType expectedType,
+      Source expectedSource,
+      Channel expectedChannel) {
+    assertEquals(transactionId, event.getEvent().getTransactionId());
+    assertThat(UUID.fromString(event.getEvent().getTransactionId()), instanceOf(UUID.class));
+    assertEquals(expectedType, event.getEvent().getType());
+    assertEquals(expectedSource, event.getEvent().getSource());
+    assertEquals(expectedChannel, event.getEvent().getChannel());
+    assertThat(event.getEvent().getDateTime(), instanceOf(Date.class));
+  }
+
+  private void verifyEventSent(GenericEvent orig, GenericEvent sent) {
+    Header origHeader = orig.getEvent();
+    Header sentHeader = sent.getEvent();
+    Date sentDate = sentHeader.getDateTime();
+    assertTrue(
+        sentDate.after(this.startOfTestDateTime) || sentDate.equals(this.startOfTestDateTime));
+    assertTrue(sentDate.after(origHeader.getDateTime()));
+    assertFalse(sentHeader.getTransactionId().equals(origHeader.getTransactionId()));
+
+    // check all other fields are the same
+    origHeader.setDateTime(sentDate);
+    origHeader.setTransactionId(sentHeader.getTransactionId());
+    assertEquals(orig, sent);
   }
 }

--- a/src/test/java/uk/gov/ons/ctp/common/event/EventPublisherWithPersistenceTest.java
+++ b/src/test/java/uk/gov/ons/ctp/common/event/EventPublisherWithPersistenceTest.java
@@ -26,7 +26,6 @@ import uk.gov.ons.ctp.common.error.CTPException;
 import uk.gov.ons.ctp.common.error.CTPException.Fault;
 import uk.gov.ons.ctp.common.event.EventPublisher.Channel;
 import uk.gov.ons.ctp.common.event.EventPublisher.EventType;
-import uk.gov.ons.ctp.common.event.EventPublisher.RoutingKey;
 import uk.gov.ons.ctp.common.event.EventPublisher.Source;
 import uk.gov.ons.ctp.common.event.model.GenericEvent;
 import uk.gov.ons.ctp.common.event.model.SurveyLaunchedEvent;
@@ -72,9 +71,8 @@ public class EventPublisherWithPersistenceTest {
             EventType.SURVEY_LAUNCHED, Source.RESPONDENT_HOME, Channel.RH, surveyLaunchedResponse);
 
     // Verify that the event was persistent following simulated Rabbit failure
-    RoutingKey routingKey = RoutingKey.forType(EventType.RESPONDENT_AUTHENTICATED);
     verify(eventPersistence, times(1))
-        .persistEvent(eq(EventType.SURVEY_LAUNCHED), eq(routingKey), eventCapture.capture());
+        .persistEvent(eq(EventType.SURVEY_LAUNCHED), eventCapture.capture());
     SurveyLaunchedEvent event = eventCapture.getValue();
     assertHeader(
         event, transactionId, EventType.SURVEY_LAUNCHED, Source.RESPONDENT_HOME, Channel.RH);
@@ -88,7 +86,7 @@ public class EventPublisherWithPersistenceTest {
     Mockito.doThrow(new AmqpException("Failed to send")).when(sender).sendEvent(any(), any());
     Mockito.doThrow(new CTPException(Fault.SYSTEM_ERROR, "Firestore broken"))
         .when(eventPersistence)
-        .persistEvent(any(), any(), any());
+        .persistEvent(any(), any());
 
     Exception e =
         assertThrows(

--- a/src/test/resources/uk/gov/ons/ctp/common/event/PackageFixture.AddressModifiedEvent.json
+++ b/src/test/resources/uk/gov/ons/ctp/common/event/PackageFixture.AddressModifiedEvent.json
@@ -1,0 +1,37 @@
+[
+  {
+    "event": {
+      "type": "ADDRESS_MODIFIED",
+      "source": "RESPONDENT_HOME",
+      "channel": "RH",
+      "dateTime": "2020-06-29T13:25:36.042Z",
+      "transactionId": "caf1ad3f-d9a2-4a0b-b8a0-cafb8e165e2a"
+    },
+    "payload": {
+      "addressModification": {
+        "collectionCase": {
+          "id": "18353ceb-28cf-4a64-bee2-c4dc556d1268"
+        },
+        "originalAddress": {
+          "addressLine1": "1 main street",
+          "addressLine2": "upper upperingham",
+          "addressLine3": "Lower Upton",
+          "townName": "Upton",
+          "postcode": "UP103UP",
+          "region": "E",
+          "uprn": "10013041069"
+        },
+        "newAddress": {
+          "addressLine1": "30 High Street",
+          "addressLine2": "Magdalen House",
+          "addressLine3": "",
+          "townName": "Exeter",
+          "postcode": "EX2 4HY",
+          "region": "W",
+          "uprn": "100041045599"
+        }
+      }
+    }
+  }
+]
+

--- a/src/test/resources/uk/gov/ons/ctp/common/event/PackageFixture.AddressNotValidEvent.json
+++ b/src/test/resources/uk/gov/ons/ctp/common/event/PackageFixture.AddressNotValidEvent.json
@@ -1,0 +1,21 @@
+[
+  {
+    "event": {
+      "type": "ADDRESS_NOT_VALID",
+      "source": "RESPONDENT_HOME",
+      "channel": "RH",
+      "dateTime": "2020-06-29T13:25:36.042Z",
+      "transactionId": "e397a32c-1261-4c78-8f25-e38f4b83885f"
+    },
+    "payload": {
+      "invalidAddress": {
+        "collectionCase": {
+          "id": "18353ceb-28cf-4a64-bee2-c4dc556d1268"
+        },
+        "reason": "DERELICT",
+        "notes": "buy weetabix"
+      }
+    }
+  }
+]
+

--- a/src/test/resources/uk/gov/ons/ctp/common/event/PackageFixture.AddressTypeChangedEvent.json
+++ b/src/test/resources/uk/gov/ons/ctp/common/event/PackageFixture.AddressTypeChangedEvent.json
@@ -1,0 +1,26 @@
+[
+  {
+    "event": {
+      "type": "ADDRESS_TYPE_CHANGED",
+      "source": "RESPONDENT_HOME",
+      "channel": "RH",
+      "dateTime": "2020-06-29T13:25:36.042Z",
+      "transactionId": "ae9bf8a4-5de4-4dc2-b616-4f7fb15025bd"
+    },
+    "payload": {
+      "addressTypeChange": {
+        "newCaseId": "18353ceb-28cf-4a64-bee2-c4dc556d1268",
+        "collectionCase": {
+          "id": "dc4477d1-dd3f-4c69-b181-7ff725dc9fa4",
+          "ceExpectedCapacity": 34,
+          "address": {
+            "addressType": "CE",
+            "estabType": "HOSTEL",
+            "organisationName": "Cyberdyne Systems"
+          }
+        }
+      }
+    }
+  }
+]
+

--- a/src/test/resources/uk/gov/ons/ctp/common/event/PackageFixture.CaseEvent.json
+++ b/src/test/resources/uk/gov/ons/ctp/common/event/PackageFixture.CaseEvent.json
@@ -1,0 +1,46 @@
+[
+  {
+    "event": {
+      "type": "CASE_CREATED",
+      "source": "RESPONDENT_HOME",
+      "channel": "RH",
+      "dateTime": "2020-06-29T13:25:36.042Z",
+      "transactionId": "191f7c80-4774-4e1b-a52c-ef8c209b90e4"
+    },
+    "payload": {
+      "collectionCase": {
+        "id": "dc4477d1-dd3f-4c69-b181-7ff725dc9fa4",
+        "caseRef": "10000000010",
+        "caseType": "HH",
+        "survey": "Census",
+        "collectionExerciseId": "n66de4dc-3c3b-11e9-b210-d663bd873d93",
+        "address": {
+          "addressLine1": "1 main street",
+          "addressLine2": "upper upperingham",
+          "addressLine3": "",
+          "townName": "upton",
+          "postcode": "UP103UP",
+          "region": "E",
+          "uprn": "XXXXXXXXXXXXX",
+          "latitude": "50.863849",
+          "longitude": "-1.229710",
+          "estabUprn": null,
+          "addressType": "CE",
+          "addressLevel": "E",
+          "estabType": "XXX"
+        },
+        "contact": {
+          "title": "Ms",
+          "forename": "jo",
+          "surname": "smith",
+          "telNo": "+447890000000"
+        },
+        "actionableFrom": "2011-08-12T20:17:46.384Z",
+        "handDelivery": true,
+        "addressInvalid": true,
+        "createdDateTime": "2020-06-05T15:05:18.717Z"
+      }
+    }
+  }
+]
+

--- a/src/test/resources/uk/gov/ons/ctp/common/event/PackageFixture.FeedbackEvent.json
+++ b/src/test/resources/uk/gov/ons/ctp/common/event/PackageFixture.FeedbackEvent.json
@@ -1,0 +1,19 @@
+[
+  {
+    "event": {
+      "type": "FEEDBACK",
+      "source": "RESPONDENT_HOME",
+      "channel": "RH",
+      "dateTime": "2020-06-29T13:25:36.042Z",
+      "transactionId": "e7757405-e318-41a1-ab24-67b3248135ef"
+    },
+    "payload": {
+      "feedback": {
+        "pageUrl": "url-x",
+        "pageTitle": "randomPage",
+        "feedbackText": "Bla bla bla"
+      }
+    }
+  }
+]
+

--- a/src/test/resources/uk/gov/ons/ctp/common/event/PackageFixture.FulfilmentRequestedEvent.json
+++ b/src/test/resources/uk/gov/ons/ctp/common/event/PackageFixture.FulfilmentRequestedEvent.json
@@ -1,0 +1,69 @@
+[
+  {
+    "event": {
+      "type": "FULFILMENT_REQUESTED",
+      "source": "CONTACT_CENTRE_API",
+      "channel": "CC",
+      "dateTime": "2020-06-29T13:25:36.042Z",
+      "transactionId": "1d91fec8-4f3a-4ce0-ad4f-165815bd5ec4"
+    },
+    "payload": {
+      "fulfilmentRequest": {
+        "fulfilmentCode": "ENH1",
+        "caseId": "id-123",
+        "individualCaseId": "ead8aa0e-793f-4489-ae26-1989e0bd76b1",
+        "contact": {
+          "title": "Ms",
+          "forename": "jo",
+          "surname": "smith",
+          "telNo": "+447890000000"
+        }
+      }
+    }
+  },
+  {
+    "event": {
+      "type": "FULFILMENT_REQUESTED",
+      "source": "CONTACT_CENTRE_API",
+      "channel": "CC",
+      "dateTime": "2020-06-29T13:25:36.042Z",
+      "transactionId": "d82637e7-bf67-44fc-a1ce-1f4ecdf35ede"
+    },
+    "payload": {
+      "fulfilmentRequest": {
+        "fulfilmentCode": "ENH1",
+        "caseId": "id-123",
+        "individualCaseId": "ead8aa0e-793f-4489-ae26-1989e0bd76b1",
+        "contact": {
+          "title": "Ms",
+          "forename": "jo",
+          "surname": "smith",
+          "telNo": "+447890000000"
+        }
+      }
+    }
+  },
+  {
+    "event": {
+      "type": "FULFILMENT_REQUESTED",
+      "source": "CONTACT_CENTRE_API",
+      "channel": "CC",
+      "dateTime": "2020-06-29T13:25:36.042Z",
+      "transactionId": "9e6456e4-fe21-48c9-8f7d-46179ecbc3d3"
+    },
+    "payload": {
+      "fulfilmentRequest": {
+        "fulfilmentCode": "ENH1",
+        "caseId": "id-123",
+        "individualCaseId": "ead8aa0e-793f-4489-ae26-1989e0bd76b1",
+        "contact": {
+          "title": "Ms",
+          "forename": "jo",
+          "surname": "smith",
+          "telNo": "+447890000000"
+        }
+      }
+    }
+  }
+]
+

--- a/src/test/resources/uk/gov/ons/ctp/common/event/PackageFixture.NewAddress.json
+++ b/src/test/resources/uk/gov/ons/ctp/common/event/PackageFixture.NewAddress.json
@@ -1,0 +1,22 @@
+{
+  "sourceCaseId": "e4cd3a0a-b175-489a-810c-3f6429aced7d",
+  "collectionCase": {
+    "id": "dc4477d1-dd3f-4c69-b181-7ff725dc9fa4",
+    "caseType": "HH",
+    "survey": "xx",
+    "collectionExerciseId": "dc4477d1-dd3f-4c69-b181-7ff725dc9fa4",
+    "organisationName": "Cyberdyne Corp",
+    "ceExpectedCapacity": 12,
+    "fieldCoordinatorId": "x",
+    "fieldOfficerId": "y",
+    "address": {
+      "latitude": "222",
+      "longitude": "333",
+      "estabUprn": "100041045599",
+      "addressType": "HH",
+      "addressLevel": "U"
+    }
+  }
+}
+
+

--- a/src/test/resources/uk/gov/ons/ctp/common/event/PackageFixture.NewAddressReportedEvent.json
+++ b/src/test/resources/uk/gov/ons/ctp/common/event/PackageFixture.NewAddressReportedEvent.json
@@ -1,0 +1,34 @@
+[
+  {
+    "event": {
+      "type": "NEW_ADDRESS_REPORTED",
+      "source": "RESPONDENT_HOME",
+      "channel": "RH",
+      "dateTime": "2020-06-29T13:25:36.042Z",
+      "transactionId": "59332dbe-8aa2-49f9-a4ba-d0a23e86a375"
+    },
+    "payload": {
+      "newAddress": {
+        "sourceCaseId": "e4cd3a0a-b175-489a-810c-3f6429aced7d",
+        "collectionCase": {
+          "id": "dc4477d1-dd3f-4c69-b181-7ff725dc9fa4",
+          "caseType": "HH",
+          "survey": "xx",
+          "collectionExerciseId": "dc4477d1-dd3f-4c69-b181-7ff725dc9fa4",
+          "organisationName": "Cyberdyne Corp",
+          "ceExpectedCapacity": 12,
+          "fieldCoordinatorId": "x",
+          "fieldOfficerId": "y",
+          "address": {
+          	"latitude":"222",
+          	"longitude": "333",
+          	"estabUprn": "100041045599",
+          	"addressType": "HH",
+          	"addressLevel": "U"
+          }
+        }
+      }
+    }
+  }
+]
+

--- a/src/test/resources/uk/gov/ons/ctp/common/event/PackageFixture.QuestionnaireLinkedEvent.json
+++ b/src/test/resources/uk/gov/ons/ctp/common/event/PackageFixture.QuestionnaireLinkedEvent.json
@@ -1,0 +1,19 @@
+[
+  {
+    "event": {
+      "type": "QUESTIONNAIRE_LINKED",
+      "source": "RESPONDENT_HOME",
+      "channel": "RH",
+      "dateTime": "2020-06-29T13:25:36.042Z",
+      "transactionId": "52dddb1c-56cf-4e12-98bf-779aa733cb57"
+    },
+    "payload": {
+      "uac": {
+        "questionnaireId": "1110000009",
+        "caseId": "dc4477d1-dd3f-4c69-b181-7ff725dc9fa4",
+        "individualCaseId": "ead8aa0e-793f-4489-ae26-1989e0bd76b1"
+      }
+    }
+  }
+]
+

--- a/src/test/resources/uk/gov/ons/ctp/common/event/PackageFixture.RespondentAuthenticatedEvent.json
+++ b/src/test/resources/uk/gov/ons/ctp/common/event/PackageFixture.RespondentAuthenticatedEvent.json
@@ -1,0 +1,18 @@
+[
+  {
+    "event": {
+      "type": "RESPONDENT_AUTHENTICATED",
+      "source": "RESPONDENT_HOME",
+      "channel": "RH",
+      "dateTime": "2020-06-29T13:25:36.042Z",
+      "transactionId": "ef23ec16-fab5-47bf-9e58-25fa6254b37e"
+    },
+    "payload": {
+      "response": {
+        "questionnaireId": "1110000009",
+        "caseId": "dc4477d1-dd3f-4c69-b181-7ff725dc9fa4"
+      }
+    }
+  }
+]
+

--- a/src/test/resources/uk/gov/ons/ctp/common/event/PackageFixture.RespondentRefusalEvent.json
+++ b/src/test/resources/uk/gov/ons/ctp/common/event/PackageFixture.RespondentRefusalEvent.json
@@ -1,0 +1,37 @@
+[
+  {
+    "event": {
+      "type": "REFUSAL_RECEIVED",
+      "source": "CONTACT_CENTRE_API",
+      "channel": "CC",
+      "dateTime": "2020-06-29T13:25:36.042Z",
+      "transactionId": "2e62f0a2-d83f-43b2-97fc-d300e2ed59cb"
+    },
+    "payload": {
+      "refusal": {
+        "type": "EXTRAORDINARY_REFUSAL",
+        "agentId": "x1",
+        "callId": "898-NOW",
+        "isHouseholder": "true",
+        "collectionCase": {
+          "id": "18353ceb-28cf-4a64-bee2-c4dc556d1268"
+        },
+        "contact": {
+          "title": "Ms",
+          "forename": "jo",
+          "surname": "smith"
+        },
+        "address": {
+          "addressLine1": "1 main street",
+          "addressLine2": "upper upperingham",
+          "addressLine3": "Lower Upton",
+          "townName": "Upton",
+          "postcode": "UP103UP",
+          "region": "E",
+          "uprn": "10013041069"
+        }
+      }
+    }
+  }
+]
+

--- a/src/test/resources/uk/gov/ons/ctp/common/event/PackageFixture.SurveyLaunchedEvent.json
+++ b/src/test/resources/uk/gov/ons/ctp/common/event/PackageFixture.SurveyLaunchedEvent.json
@@ -1,0 +1,19 @@
+[
+  {
+    "event": {
+      "type": "SURVEY_LAUNCHED",
+      "source": "RESPONDENT_HOME",
+      "channel": "RH",
+      "dateTime": "2020-06-29T13:25:36.042Z",
+      "transactionId": "14490f12-cb0b-459d-921e-cd4c59613268"
+    },
+    "payload": {
+      "response": {
+        "questionnaireId": "1110000009",
+        "caseId": "dc4477d1-dd3f-4c69-b181-7ff725dc9fa4",
+        "agentId" : "x1"
+      }
+    }
+  }
+]
+

--- a/src/test/resources/uk/gov/ons/ctp/common/event/PackageFixture.UAC.json
+++ b/src/test/resources/uk/gov/ons/ctp/common/event/PackageFixture.UAC.json
@@ -1,0 +1,6 @@
+{
+  "uacHash": "8a9d5db4bbee34fd16e40aa2aaae52cfbdf1842559023614c30edb480ec252b4",
+  "active": true,
+  "questionnaireId": "1110000009",
+  "formType": "I"
+}

--- a/src/test/resources/uk/gov/ons/ctp/common/event/PackageFixture.UACEvent.json
+++ b/src/test/resources/uk/gov/ons/ctp/common/event/PackageFixture.UACEvent.json
@@ -1,0 +1,20 @@
+[
+  {
+    "event": {
+      "type": "UAC_CREATED",
+      "source": "RESPONDENT_HOME",
+      "channel": "RH",
+      "dateTime": "2020-06-29T13:25:36.042Z",
+      "transactionId": "2985d223-e967-4c98-a3d5-07e4c9deeef4"
+    },
+    "payload": {
+      "uac": {
+        "uacHash": "8a9d5db4bbee34fd16e40aa2aaae52cfbdf1842559023614c30edb480ec252b4",
+        "active": true,
+        "questionnaireId": "1110000009",
+        "formType": "I"
+      }
+    }
+  }
+]
+


### PR DESCRIPTION
When creating the "**event-replayer**" code (CR-1065) for replaying stored events the following was discovered:

- the existing **EventBackupData** object did not store in Firestore correctly (particularly **UUID** which was then difficult to deserialise)
- storing the generic Event did not make it easy to restore the payload data.
- a large switch statement similar to that in the **EventPublisher** class was required to recover the payload and other data from the backup event. The problem with that is keeping that level of detail in the **event-replayer** code has a high degree of danger that it will go out of step with the event publisher model objects as changes occur.

To address these the following changes do the following:
- modify the **EventBackupData** class to store the payload as JSON string which can be serialised/deserialised under our control , avoiding Firestore limitations, and easing the restore of the event object
- add a send method to the Event publisher to handle deserialising and sending the JSON backup object. This keeps the code together and makes it much harder for divergence
- refactor the big **switch** statements into subclassed behaviour for reuse between sending logic and deserialisation logic.

Unit tests have been added for all events for through the new send method, and additional tests have been added for the missing events for the original path.
