### PR TITLE
Cr 1190 circuit breaker

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,12 @@
       <artifactId>spring-rabbit</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.springframework.cloud</groupId>
+      <artifactId>spring-cloud-starter-circuitbreaker-resilience4j</artifactId>
+      <version>1.0.4.RELEASE</version>
+    </dependency>
+
     <!-- ONS libraries -->
 
     <dependency>

--- a/src/main/java/uk/gov/ons/ctp/common/event/EventCircuitBreakerException.java
+++ b/src/main/java/uk/gov/ons/ctp/common/event/EventCircuitBreakerException.java
@@ -1,0 +1,17 @@
+package uk.gov.ons.ctp.common.event;
+
+public class EventCircuitBreakerException extends EventPublishException {
+  private static final long serialVersionUID = 7928252329309913211L;
+
+  public EventCircuitBreakerException(String message) {
+    super(message);
+  }
+
+  public EventCircuitBreakerException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public EventCircuitBreakerException(Throwable cause) {
+    super("Failed send within circuit breaker", cause);
+  }
+}

--- a/src/main/java/uk/gov/ons/ctp/common/event/EventPublisher.java
+++ b/src/main/java/uk/gov/ons/ctp/common/event/EventPublisher.java
@@ -173,13 +173,9 @@ public class EventPublisher {
    * @param eventSender the impl of EventSender that will be used to ... send the event.
    * @param eventPersistence is an EventPersistence implementation which does the actual event
    *     persistence.
+   * @param circuitBreaker circuit breaker object, or null if not required.
    * @return an EventPubisher object.
    */
-  public static EventPublisher createWithEventPersistence(
-      EventSender eventSender, EventPersistence eventPersistence) {
-    return new EventPublisher(eventSender, eventPersistence, null);
-  }
-
   public static EventPublisher createWithEventPersistence(
       EventSender eventSender, EventPersistence eventPersistence, CircuitBreaker circuitBreaker) {
     return new EventPublisher(eventSender, eventPersistence, circuitBreaker);

--- a/src/main/java/uk/gov/ons/ctp/common/event/EventPublisher.java
+++ b/src/main/java/uk/gov/ons/ctp/common/event/EventPublisher.java
@@ -305,11 +305,7 @@ public class EventPublisher {
     } else {
       this.circuitBreaker.run(
           () -> {
-            try {
-              sender.sendEvent(routingKey, genericEvent);
-            } catch (Exception e) {
-              throw new RuntimeException(e);
-            }
+            sender.sendEvent(routingKey, genericEvent);
             return null;
           });
     }

--- a/src/main/java/uk/gov/ons/ctp/common/event/EventPublisher.java
+++ b/src/main/java/uk/gov/ons/ctp/common/event/EventPublisher.java
@@ -305,7 +305,7 @@ public class EventPublisher {
               throw new EventCircuitBreakerException(throwable);
             });
       } catch (EventCircuitBreakerException e) {
-        log.warn("{}: {}", e.getMessage(), e.getCause().getMessage());
+        log.debug("{}: {}", e.getMessage(), e.getCause().getMessage());
         throw e;
       }
     }

--- a/src/main/java/uk/gov/ons/ctp/common/event/EventSender.java
+++ b/src/main/java/uk/gov/ons/ctp/common/event/EventSender.java
@@ -5,7 +5,7 @@ import uk.gov.ons.ctp.common.event.model.GenericEvent;
 
 public interface EventSender {
 
-  void sendEvent(RoutingKey routingKey, GenericEvent genericEvent) throws Exception;
+  void sendEvent(RoutingKey routingKey, GenericEvent genericEvent);
 
   default void close() throws Exception {}
 }

--- a/src/main/java/uk/gov/ons/ctp/common/event/NativeRabbitEventSender.java
+++ b/src/main/java/uk/gov/ons/ctp/common/event/NativeRabbitEventSender.java
@@ -67,11 +67,15 @@ public class NativeRabbitEventSender implements EventSender {
   }
 
   @Override
-  public void sendEvent(RoutingKey routingKey, GenericEvent genericEvent) throws Exception {
-    channel.basicPublish(
-        exchange,
-        routingKey.getKey(),
-        null,
-        objectMapper.writeValueAsString(genericEvent).getBytes("UTF-8"));
+  public void sendEvent(RoutingKey routingKey, GenericEvent genericEvent) {
+    try {
+      channel.basicPublish(
+          exchange,
+          routingKey.getKey(),
+          null,
+          objectMapper.writeValueAsString(genericEvent).getBytes("UTF-8"));
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
   }
 }

--- a/src/test/java/uk/gov/ons/ctp/common/event/EventPublisherTest.java
+++ b/src/test/java/uk/gov/ons/ctp/common/event/EventPublisherTest.java
@@ -1,7 +1,6 @@
 package uk.gov.ons.ctp.common.event;
 
 import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -11,11 +10,11 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static uk.gov.ons.ctp.common.event.EventPublisherTestUtil.assertHeader;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Date;
-import java.util.UUID;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -619,20 +618,6 @@ public class EventPublisherTest {
 
   private <T> T loadJson(Class<T[]> clazz) {
     return FixtureHelper.loadPackageFixtures(clazz).get(0);
-  }
-
-  private void assertHeader(
-      GenericEvent event,
-      String transactionId,
-      EventType expectedType,
-      Source expectedSource,
-      Channel expectedChannel) {
-    assertEquals(transactionId, event.getEvent().getTransactionId());
-    assertThat(UUID.fromString(event.getEvent().getTransactionId()), instanceOf(UUID.class));
-    assertEquals(expectedType, event.getEvent().getType());
-    assertEquals(expectedSource, event.getEvent().getSource());
-    assertEquals(expectedChannel, event.getEvent().getChannel());
-    assertThat(event.getEvent().getDateTime(), instanceOf(Date.class));
   }
 
   private void verifyEventSent(GenericEvent orig, GenericEvent sent) {

--- a/src/test/java/uk/gov/ons/ctp/common/event/EventPublisherTest.java
+++ b/src/test/java/uk/gov/ons/ctp/common/event/EventPublisherTest.java
@@ -101,7 +101,7 @@ public class EventPublisherTest {
 
   @Test
   public void shouldCreateWithEventPersistence() {
-    EventPublisher ep = EventPublisher.createWithEventPersistence(sender, eventPersistence);
+    EventPublisher ep = EventPublisher.createWithEventPersistence(sender, eventPersistence, null);
     assertNotNull(ReflectionTestUtils.getField(ep, "eventPersistence"));
     assertEquals(sender, ReflectionTestUtils.getField(ep, "sender"));
   }

--- a/src/test/java/uk/gov/ons/ctp/common/event/EventPublisherTestUtil.java
+++ b/src/test/java/uk/gov/ons/ctp/common/event/EventPublisherTestUtil.java
@@ -1,0 +1,32 @@
+package uk.gov.ons.ctp.common.event;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+
+import java.util.Date;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import uk.gov.ons.ctp.common.event.EventPublisher.Channel;
+import uk.gov.ons.ctp.common.event.EventPublisher.EventType;
+import uk.gov.ons.ctp.common.event.EventPublisher.Source;
+import uk.gov.ons.ctp.common.event.model.GenericEvent;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class EventPublisherTestUtil {
+
+  static void assertHeader(
+      GenericEvent event,
+      String transactionId,
+      EventType expectedType,
+      Source expectedSource,
+      Channel expectedChannel) {
+    assertEquals(transactionId, event.getEvent().getTransactionId());
+    assertThat(UUID.fromString(event.getEvent().getTransactionId()), instanceOf(UUID.class));
+    assertEquals(expectedType, event.getEvent().getType());
+    assertEquals(expectedSource, event.getEvent().getSource());
+    assertEquals(expectedChannel, event.getEvent().getChannel());
+    assertThat(event.getEvent().getDateTime(), instanceOf(Date.class));
+  }
+}

--- a/src/test/java/uk/gov/ons/ctp/common/event/EventPublisherWithCircuitBreakerTest.java
+++ b/src/test/java/uk/gov/ons/ctp/common/event/EventPublisherWithCircuitBreakerTest.java
@@ -1,0 +1,124 @@
+package uk.gov.ons.ctp.common.event;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static uk.gov.ons.ctp.common.event.EventPublisherTestUtil.assertHeader;
+
+import java.util.function.Function;
+import java.util.function.Supplier;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.stubbing.Answer;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.cloud.client.circuitbreaker.CircuitBreaker;
+import uk.gov.ons.ctp.common.FixtureHelper;
+import uk.gov.ons.ctp.common.event.EventPublisher.Channel;
+import uk.gov.ons.ctp.common.event.EventPublisher.EventType;
+import uk.gov.ons.ctp.common.event.EventPublisher.RoutingKey;
+import uk.gov.ons.ctp.common.event.EventPublisher.Source;
+import uk.gov.ons.ctp.common.event.model.SurveyLaunchedEvent;
+import uk.gov.ons.ctp.common.event.model.SurveyLaunchedResponse;
+import uk.gov.ons.ctp.common.event.persistence.FirestoreEventPersistence;
+
+/** EventPublisher tests with circuit breaker */
+@RunWith(MockitoJUnitRunner.class)
+public class EventPublisherWithCircuitBreakerTest {
+
+  @InjectMocks private EventPublisher eventPublisher;
+  @Mock private RabbitTemplate template;
+  @Mock private SpringRabbitEventSender sender;
+  @Mock private FirestoreEventPersistence eventPersistence;
+  @Mock private CircuitBreaker circuitBreaker;
+
+  @Captor private ArgumentCaptor<SurveyLaunchedEvent> surveyLaunchedEventCaptor;
+
+  private void mockCircuitBreakerRun() {
+    doAnswer(
+            new Answer<Object>() {
+              @SuppressWarnings("unchecked")
+              @Override
+              public Object answer(InvocationOnMock invocation) throws Throwable {
+                Object[] args = invocation.getArguments();
+                Supplier<Object> runner = (Supplier<Object>) args[0];
+                return runner.get();
+              }
+            })
+        .when(circuitBreaker)
+        .run(any(), any());
+  }
+
+  private void mockCircuitBreakerFail() {
+    doAnswer(
+            new Answer<Object>() {
+              @SuppressWarnings("unchecked")
+              @Override
+              public Object answer(InvocationOnMock invocation) throws Throwable {
+                Object[] args = invocation.getArguments();
+                Supplier<Object> runner = (Supplier<Object>) args[0];
+                Function<Throwable, Object> fallback = (Function<Throwable, Object>) args[1];
+
+                try {
+                  runner.get();
+                } catch (Exception e) {
+                  fallback.apply(e);
+                }
+                return null;
+              }
+            })
+        .when(circuitBreaker)
+        .run(any(), any());
+  }
+
+  @Test
+  public void shouldSendEventThroughCircuitBreaker() throws Exception {
+    mockCircuitBreakerRun();
+    SurveyLaunchedResponse surveyLaunchedResponse = loadJson(SurveyLaunchedResponse[].class);
+
+    String transactionId =
+        eventPublisher.sendEvent(
+            EventType.SURVEY_LAUNCHED, Source.RESPONDENT_HOME, Channel.RH, surveyLaunchedResponse);
+
+    RoutingKey routingKey = RoutingKey.forType(EventType.SURVEY_LAUNCHED);
+    verify(sender, times(1)).sendEvent(eq(routingKey), surveyLaunchedEventCaptor.capture());
+    SurveyLaunchedEvent event = surveyLaunchedEventCaptor.getValue();
+    assertHeader(
+        event, transactionId, EventType.SURVEY_LAUNCHED, Source.RESPONDENT_HOME, Channel.RH);
+    assertEquals(surveyLaunchedResponse, event.getPayload().getResponse());
+
+    // since it succeeded, the event is NOT sent to firestore
+    verify(eventPersistence, never()).persistEvent(eq(EventType.SURVEY_LAUNCHED), any());
+  }
+
+  @Test
+  public void shouldNotSendEventToRabbitThroughCircuitBreakerWhenRabbitFails() throws Exception {
+    mockCircuitBreakerFail();
+    Mockito.doThrow(new RuntimeException("rabbit fail")).when(sender).sendEvent(any(), any());
+
+    SurveyLaunchedResponse surveyLaunchedResponse = loadJson(SurveyLaunchedResponse[].class);
+
+    eventPublisher.sendEvent(
+        EventType.SURVEY_LAUNCHED, Source.RESPONDENT_HOME, Channel.RH, surveyLaunchedResponse);
+
+    RoutingKey routingKey = RoutingKey.forType(EventType.SURVEY_LAUNCHED);
+    verify(sender).sendEvent(eq(routingKey), surveyLaunchedEventCaptor.capture());
+
+    // since it failed, the event is sent to firestore
+    verify(eventPersistence).persistEvent(eq(EventType.SURVEY_LAUNCHED), any());
+  }
+
+  private <T> T loadJson(Class<T[]> clazz) {
+    return FixtureHelper.loadPackageFixtures(clazz).get(0);
+  }
+}

--- a/src/test/java/uk/gov/ons/ctp/common/event/EventPublisherWithPersistenceTest.java
+++ b/src/test/java/uk/gov/ons/ctp/common/event/EventPublisherWithPersistenceTest.java
@@ -1,7 +1,5 @@
 package uk.gov.ons.ctp.common.event;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
@@ -9,9 +7,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static uk.gov.ons.ctp.common.event.EventPublisherTestUtil.assertHeader;
 
-import java.util.Date;
-import java.util.UUID;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
@@ -27,7 +24,6 @@ import uk.gov.ons.ctp.common.error.CTPException.Fault;
 import uk.gov.ons.ctp.common.event.EventPublisher.Channel;
 import uk.gov.ons.ctp.common.event.EventPublisher.EventType;
 import uk.gov.ons.ctp.common.event.EventPublisher.Source;
-import uk.gov.ons.ctp.common.event.model.GenericEvent;
 import uk.gov.ons.ctp.common.event.model.SurveyLaunchedEvent;
 import uk.gov.ons.ctp.common.event.model.SurveyLaunchedResponse;
 import uk.gov.ons.ctp.common.event.persistence.FirestoreEventPersistence;
@@ -42,20 +38,6 @@ public class EventPublisherWithPersistenceTest {
   @Mock private RabbitTemplate template;
   @Mock private SpringRabbitEventSender sender;
   @Mock private FirestoreEventPersistence eventPersistence;
-
-  private void assertHeader(
-      GenericEvent event,
-      String transactionId,
-      EventType expectedType,
-      Source expectedSource,
-      Channel expectedChannel) {
-    assertEquals(transactionId, event.getEvent().getTransactionId());
-    assertThat(UUID.fromString(event.getEvent().getTransactionId()), instanceOf(UUID.class));
-    assertEquals(expectedType, event.getEvent().getType());
-    assertEquals(expectedSource, event.getEvent().getSource());
-    assertEquals(expectedChannel, event.getEvent().getChannel());
-    assertThat(event.getEvent().getDateTime(), instanceOf(Date.class));
-  }
 
   @Test
   public void eventPersistedWhenRabbitFails() throws CTPException {


### PR DESCRIPTION
During the implementation of CR-1065 (Event-replayer) it was observed during testing that running a service while RabbitMQ was down meant that the service started to shut down quite quickly: it could only handle very low load. 

This change adds the Spring cloud circuit-breaker (which will be configured by the calling service and passed to the EventPublisher) to stop continual calling of rabbit when it has previously been out of action, and thus reduce the load on the service.