### PR TITLE
CR-1280_Web_form_rabbit_message

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/common/event/EventBuilder.java
+++ b/src/main/java/uk/gov/ons/ctp/common/event/EventBuilder.java
@@ -72,7 +72,7 @@ public abstract class EventBuilder {
   public static final EventBuilder NEW_ADDRESS_REPORTED = new NewAddressReportedBuilder();
   public static final EventBuilder FEEDBACK = new FeedbackBuilder();
   public static final EventBuilder QUESTIONNAIRE_LINKED = new QuestionnaireLinkedBuilder();
-  public static final EventBuilder WEBFORM_REQUEST = new WebformBuilder();
+  public static final EventBuilder WEB_FORM_REQUEST = new WebformBuilder();
 
   ObjectMapper objectMapper = new CustomObjectMapper();
 

--- a/src/main/java/uk/gov/ons/ctp/common/event/EventBuilder.java
+++ b/src/main/java/uk/gov/ons/ctp/common/event/EventBuilder.java
@@ -47,6 +47,9 @@ import uk.gov.ons.ctp.common.event.model.SurveyLaunchedResponse;
 import uk.gov.ons.ctp.common.event.model.UAC;
 import uk.gov.ons.ctp.common.event.model.UACEvent;
 import uk.gov.ons.ctp.common.event.model.UACPayload;
+import uk.gov.ons.ctp.common.event.model.Webform;
+import uk.gov.ons.ctp.common.event.model.WebformEvent;
+import uk.gov.ons.ctp.common.event.model.WebformPayload;
 import uk.gov.ons.ctp.common.jackson.CustomObjectMapper;
 
 /**
@@ -69,6 +72,7 @@ public abstract class EventBuilder {
   public static final EventBuilder NEW_ADDRESS_REPORTED = new NewAddressReportedBuilder();
   public static final EventBuilder FEEDBACK = new FeedbackBuilder();
   public static final EventBuilder QUESTIONNAIRE_LINKED = new QuestionnaireLinkedBuilder();
+  public static final EventBuilder WEBFORM_REQUEST = new WebformBuilder();
 
   ObjectMapper objectMapper = new CustomObjectMapper();
 
@@ -412,6 +416,25 @@ public abstract class EventBuilder {
     SendInfo create(String json) {
       GenericEvent genericEvent = deserialiseEventJson(json, QuestionnaireLinkedEvent.class);
       EventPayload payload = ((QuestionnaireLinkedEvent) genericEvent).getPayload().getUac();
+      return build(genericEvent, payload);
+    }
+  }
+
+  public static class WebformBuilder extends EventBuilder {
+    @Override
+    GenericEvent create(SendInfo sendInfo) {
+      WebformEvent webformEvent = new WebformEvent();
+      webformEvent.setEvent(
+          buildHeader(EventType.WEB_FORM_REQUEST, sendInfo.getSource(), sendInfo.getChannel()));
+      WebformPayload webformPayload = new WebformPayload((Webform) sendInfo.getPayload());
+      webformEvent.setPayload(webformPayload);
+      return webformEvent;
+    }
+
+    @Override
+    SendInfo create(String json) {
+      GenericEvent genericEvent = deserialiseEventJson(json, WebformEvent.class);
+      EventPayload payload = ((WebformEvent) genericEvent).getPayload().getWebform();
       return build(genericEvent, payload);
     }
   }

--- a/src/main/java/uk/gov/ons/ctp/common/event/EventPublisher.java
+++ b/src/main/java/uk/gov/ons/ctp/common/event/EventPublisher.java
@@ -62,7 +62,7 @@ public class EventPublisher {
     EVENT_SAMPLE_UNIT_UPDATE("event.sampleunit.update", EventType.SAMPLE_UNIT_VALIDATED),
     EVENT_CCS_PROPERTY_LISTING("event.ccs.propertylisting", EventType.CCS_PROPERTY_LISTED),
     FEEDBACK("event.website.feedback", EventType.FEEDBACK),
-    WEBFORM_REQUEST("event.rh.webform", EventType.WEB_FORM_REQUEST);
+    WEB_FORM_REQUEST("event.rh.webform", EventType.WEB_FORM_REQUEST);
 
     private String key;
     private List<EventType> eventTypes;
@@ -106,7 +106,7 @@ public class EventPublisher {
     UAC_UPDATED(UAC.class, EventBuilder.UAC_UPDATED),
     UNDELIVERED_MAIL_REPORTED,
     FEEDBACK(Feedback.class, EventBuilder.FEEDBACK),
-    WEB_FORM_REQUEST(Webform.class, EventBuilder.WEBFORM_REQUEST);
+    WEB_FORM_REQUEST(Webform.class, EventBuilder.WEB_FORM_REQUEST);
 
     private Class<? extends EventPayload> payloadType;
     private EventBuilder builder;

--- a/src/main/java/uk/gov/ons/ctp/common/event/EventPublisher.java
+++ b/src/main/java/uk/gov/ons/ctp/common/event/EventPublisher.java
@@ -21,6 +21,7 @@ import uk.gov.ons.ctp.common.event.model.RespondentAuthenticatedResponse;
 import uk.gov.ons.ctp.common.event.model.RespondentRefusalDetails;
 import uk.gov.ons.ctp.common.event.model.SurveyLaunchedResponse;
 import uk.gov.ons.ctp.common.event.model.UAC;
+import uk.gov.ons.ctp.common.event.model.Webform;
 import uk.gov.ons.ctp.common.event.persistence.EventBackupData;
 import uk.gov.ons.ctp.common.event.persistence.EventPersistence;
 
@@ -60,7 +61,8 @@ public class EventPublisher {
     EVENT_FIELD_CASE_UPDATE("event.fieldcase.update", EventType.FIELD_CASE_UPDATED),
     EVENT_SAMPLE_UNIT_UPDATE("event.sampleunit.update", EventType.SAMPLE_UNIT_VALIDATED),
     EVENT_CCS_PROPERTY_LISTING("event.ccs.propertylisting", EventType.CCS_PROPERTY_LISTED),
-    FEEDBACK("event.website.feedback", EventType.FEEDBACK);
+    FEEDBACK("event.website.feedback", EventType.FEEDBACK),
+    WEBFORM_REQUEST("event.rh.webform", EventType.WEB_FORM_REQUEST);
 
     private String key;
     private List<EventType> eventTypes;
@@ -103,7 +105,8 @@ public class EventPublisher {
     UAC_CREATED(UAC.class, EventBuilder.UAC_CREATED),
     UAC_UPDATED(UAC.class, EventBuilder.UAC_UPDATED),
     UNDELIVERED_MAIL_REPORTED,
-    FEEDBACK(Feedback.class, EventBuilder.FEEDBACK);
+    FEEDBACK(Feedback.class, EventBuilder.FEEDBACK),
+    WEB_FORM_REQUEST(Webform.class, EventBuilder.WEBFORM_REQUEST);
 
     private Class<? extends EventPayload> payloadType;
     private EventBuilder builder;

--- a/src/main/java/uk/gov/ons/ctp/common/event/model/Webform.java
+++ b/src/main/java/uk/gov/ons/ctp/common/event/model/Webform.java
@@ -1,0 +1,49 @@
+package uk.gov.ons.ctp.common.event.model;
+
+import com.godaddy.logging.LoggingScope;
+import com.godaddy.logging.Scope;
+import javax.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import uk.gov.ons.ctp.common.domain.Region;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class Webform implements EventPayload {
+
+  /** enum for category */
+  public enum WebformCategory {
+    MISSING_INFORMATION,
+    TECHNICAL,
+    FORM,
+    COMPLAINT,
+    ADDRESS,
+    OTHER
+  }
+
+  /** enum for language */
+  public enum WebformLanguage {
+    EN,
+    CY
+  }
+
+  @NotNull private WebformCategory category;
+
+  @NotNull private Region region;
+
+  @NotNull private WebformLanguage language;
+
+  @NotNull
+  @LoggingScope(scope = Scope.SKIP)
+  private String name;
+
+  @NotNull
+  @LoggingScope(scope = Scope.SKIP)
+  private String description;
+
+  @NotNull
+  @LoggingScope(scope = Scope.SKIP)
+  private String email;
+}

--- a/src/main/java/uk/gov/ons/ctp/common/event/model/WebformEvent.java
+++ b/src/main/java/uk/gov/ons/ctp/common/event/model/WebformEvent.java
@@ -1,0 +1,15 @@
+package uk.gov.ons.ctp.common.event.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+@NoArgsConstructor
+@AllArgsConstructor
+public class WebformEvent extends GenericEvent {
+
+  private WebformPayload payload = new WebformPayload();
+}

--- a/src/main/java/uk/gov/ons/ctp/common/event/model/WebformPayload.java
+++ b/src/main/java/uk/gov/ons/ctp/common/event/model/WebformPayload.java
@@ -1,0 +1,13 @@
+package uk.gov.ons.ctp.common.event.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class WebformPayload {
+
+  private Webform webform = new Webform();
+}

--- a/src/test/java/uk/gov/ons/ctp/common/event/EventPublisherTest.java
+++ b/src/test/java/uk/gov/ons/ctp/common/event/EventPublisherTest.java
@@ -58,6 +58,8 @@ import uk.gov.ons.ctp.common.event.model.SurveyLaunchedEvent;
 import uk.gov.ons.ctp.common.event.model.SurveyLaunchedResponse;
 import uk.gov.ons.ctp.common.event.model.UAC;
 import uk.gov.ons.ctp.common.event.model.UACEvent;
+import uk.gov.ons.ctp.common.event.model.Webform;
+import uk.gov.ons.ctp.common.event.model.WebformEvent;
 import uk.gov.ons.ctp.common.event.persistence.EventBackupData;
 import uk.gov.ons.ctp.common.event.persistence.FirestoreEventPersistence;
 import uk.gov.ons.ctp.common.jackson.CustomObjectMapper;
@@ -84,6 +86,7 @@ public class EventPublisherTest {
   @Captor private ArgumentCaptor<FeedbackEvent> feedbackEventCaptor;
   @Captor private ArgumentCaptor<NewAddressReportedEvent> newAddressReportedEventCaptor;
   @Captor private ArgumentCaptor<QuestionnaireLinkedEvent> questionnaireLinkedEventCaptor;
+  @Captor private ArgumentCaptor<WebformEvent> webformEventCaptor;
 
   private Date startOfTestDateTime;
 
@@ -372,6 +375,21 @@ public class EventPublisherTest {
     assertSendUac(EventType.UAC_UPDATED);
   }
 
+  @Test
+  public void shouldSendWebformEvent() {
+    Webform payload = loadJson(Webform[].class);
+    String transactionId =
+        eventPublisher.sendEvent(
+            EventType.WEB_FORM_REQUEST, Source.RESPONDENT_HOME, Channel.RH, payload);
+    RoutingKey routingKey = RoutingKey.forType(EventType.WEB_FORM_REQUEST);
+    verify(sender, times(1)).sendEvent(eq(routingKey), webformEventCaptor.capture());
+
+    WebformEvent event = webformEventCaptor.getValue();
+    assertHeader(
+        event, transactionId, EventType.WEB_FORM_REQUEST, Source.RESPONDENT_HOME, Channel.RH);
+    assertEquals(payload, event.getPayload().getWebform());
+  }
+
   @Test(expected = IllegalArgumentException.class)
   public void shouldRejectSendForMismatchingPayload() {
     Feedback feedbackResponse = loadJson(Feedback[].class);
@@ -526,6 +544,16 @@ public class EventPublisherTest {
     verifyEventSent(ev, questionnaireLinkedEventCaptor.getValue());
   }
 
+  @Test
+  public void shouldSendBackupWebformEvent() throws Exception {
+    WebformEvent ev = aWebformEvent();
+    sendBackupEvent(ev);
+
+    RoutingKey routingKey = RoutingKey.forType(EventType.WEB_FORM_REQUEST);
+    verify(sender).sendEvent(eq(routingKey), webformEventCaptor.capture());
+    verifyEventSent(ev, webformEventCaptor.getValue());
+  }
+
   @Test(expected = UnsupportedOperationException.class)
   public void shouldRejectEventWithoutPayload() throws Exception {
     QuestionnaireLinkedEvent ev = aQuestionnaireLinkedEvent();
@@ -614,6 +642,10 @@ public class EventPublisherTest {
 
   QuestionnaireLinkedEvent aQuestionnaireLinkedEvent() {
     return FixtureHelper.loadPackageFixtures(QuestionnaireLinkedEvent[].class).get(0);
+  }
+
+  WebformEvent aWebformEvent() {
+    return FixtureHelper.loadPackageFixtures(WebformEvent[].class).get(0);
   }
 
   private <T> T loadJson(Class<T[]> clazz) {

--- a/src/test/resources/uk/gov/ons/ctp/common/event/PackageFixture.Webform.json
+++ b/src/test/resources/uk/gov/ons/ctp/common/event/PackageFixture.Webform.json
@@ -1,0 +1,8 @@
+{
+  "category": "COMPLAINT",
+  "region": "E",
+  "language": "EN", 
+  "name": "Bill Bloggs",
+  "description": "Computer says no",
+  "email": "bb@yahoo.co.uk"
+}

--- a/src/test/resources/uk/gov/ons/ctp/common/event/PackageFixture.WebformEvent.json
+++ b/src/test/resources/uk/gov/ons/ctp/common/event/PackageFixture.WebformEvent.json
@@ -1,0 +1,21 @@
+[
+  {
+    "event": {
+      "type": "WEB_FORM_REQUEST",
+      "source": "RESPONDENT_HOME",
+      "channel": "RH",
+      "dateTime": "2020-06-29T13:25:36.042Z",
+      "transactionId": "2985d223-e967-4c98-a3d5-07e4c9deeef4"
+    },
+    "payload": {
+      "webform": {
+        "category": "COMPLAINT",
+        "region": "E",
+        "language": "EN", 
+        "name": "Bill Bloggs",
+        "description": "Computer says no",
+        "email": "bb@yahoo.co.uk"    
+      }
+    }
+  }
+]


### PR DESCRIPTION
# Motivation and Context
Add ability to send WEB_FORM_REQUEST event

# What has changed
New event type published to Rabbit to capture web form requests for help by email.

# How to test?
Unit tests added.

# Links
Event dictionary: https://collaborate2.ons.gov.uk/confluence/pages/viewpage.action?spaceKey=CATD&title=Response+Management+Event+Dictionary
JIRA: https://collaborate2.ons.gov.uk/jira/browse/CR-1280
